### PR TITLE
Add Gatekeeper opensrp info getter

### DIFF
--- a/packages/gatekeeper/dist/helpers/oauth.js
+++ b/packages/gatekeeper/dist/helpers/oauth.js
@@ -7,6 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.getProviderFromOptions = getProviderFromOptions;
 exports.getOnadataUserInfo = getOnadataUserInfo;
+exports.getOpenSRPUserInfo = getOpenSRPUserInfo;
 
 var _clientOauth = _interopRequireDefault(require("client-oauth2"));
 
@@ -34,17 +35,31 @@ function getOnadataUserInfo(apiResponse) {
     throw new Error(_constants.OAUTH2_CALLBACK_ERROR);
   }
 
-  var username = apiResponse.username;
-  var user = {
-    email: apiResponse.email || '',
-    gravatar: apiResponse.gravatar || '',
-    name: apiResponse.name || '',
-    username: username
-  };
-  var extraData = apiResponse;
   return {
     authenticated: true,
-    extraData: extraData,
-    user: user
+    extraData: apiResponse,
+    user: {
+      email: apiResponse.email || '',
+      gravatar: apiResponse.gravatar || '',
+      name: apiResponse.name || '',
+      username: apiResponse.username
+    }
+  };
+}
+
+function getOpenSRPUserInfo(apiResponse) {
+  if (!apiResponse.userName) {
+    throw new Error(_constants.OAUTH2_CALLBACK_ERROR);
+  }
+
+  return {
+    authenticated: true,
+    extraData: apiResponse,
+    user: {
+      email: '',
+      gravatar: '',
+      name: '',
+      username: apiResponse.userName
+    }
   };
 }

--- a/packages/gatekeeper/dist/helpers/services.js
+++ b/packages/gatekeeper/dist/helpers/services.js
@@ -101,7 +101,7 @@ function _fetchUser() {
         userInfoCallback,
         errorCallbackFn,
         method,
-        userInfo,
+        responseInfo,
         authenticated,
         user,
         extraData,
@@ -120,10 +120,10 @@ function _fetchUser() {
             return oauth2Callback(locationHash, url, provider, userInfoCallback, method);
 
           case 8:
-            userInfo = _context3.sent;
+            responseInfo = _context3.sent;
 
-            if (userInfo) {
-              authenticated = userInfo.authenticated, user = userInfo.user, extraData = userInfo.extraData;
+            if (responseInfo) {
+              authenticated = responseInfo.authenticated, user = responseInfo.user, extraData = responseInfo.extraData;
               authenticateActionCreator(authenticated, user, extraData);
               recordResultActionCreator(true, extraData);
             } else {

--- a/packages/gatekeeper/dist/index.js
+++ b/packages/gatekeeper/dist/index.js
@@ -179,6 +179,12 @@ Object.defineProperty(exports, "getOnadataUserInfo", {
     return _oauth.getOnadataUserInfo;
   }
 });
+Object.defineProperty(exports, "getOpenSRPUserInfo", {
+  enumerable: true,
+  get: function get() {
+    return _oauth.getOpenSRPUserInfo;
+  }
+});
 Object.defineProperty(exports, "getProviderFromOptions", {
   enumerable: true,
   get: function get() {

--- a/packages/gatekeeper/dist/types/helpers/oauth.d.ts
+++ b/packages/gatekeeper/dist/types/helpers/oauth.d.ts
@@ -20,3 +20,7 @@ export declare type UserInfoFnType = (obj: { [key: string]: any }) => SessionSta
 export declare function getOnadataUserInfo(apiResponse: {
   [key: string]: any;
 }): SessionState | void;
+/** Function to get OpenSRP user info from api response object
+ * @param {{[key: string]: any }} apiResponse - the API response object
+ */
+export declare function getOpenSRPUserInfo(apiResponse: { [key: string]: any }): SessionState;

--- a/packages/gatekeeper/dist/types/index.d.ts
+++ b/packages/gatekeeper/dist/types/index.d.ts
@@ -24,6 +24,7 @@ import gateKeeperReducer, {
 } from './ducks/gatekeeper';
 import {
   getOnadataUserInfo,
+  getOpenSRPUserInfo,
   getProviderFromOptions,
   OauthOptions,
   Providers,
@@ -39,6 +40,7 @@ export {
   gateKeeperReducer,
   gateKeeperReducerName,
   getOnadataUserInfo,
+  getOpenSRPUserInfo,
   getProviderFromOptions,
   getResult,
   getSuccess,

--- a/packages/gatekeeper/src/helpers/oauth.ts
+++ b/packages/gatekeeper/src/helpers/oauth.ts
@@ -37,18 +37,15 @@ export function getOnadataUserInfo(apiResponse: { [key: string]: any }): Session
   if (!apiResponse.username || !apiResponse.api_token) {
     throw new Error(OAUTH2_CALLBACK_ERROR);
   }
-  const { username } = apiResponse;
-  const user = {
-    email: apiResponse.email || '',
-    gravatar: apiResponse.gravatar || '',
-    name: apiResponse.name || '',
-    username
-  };
-  const extraData = apiResponse;
   return {
     authenticated: true,
-    extraData,
-    user
+    extraData: apiResponse,
+    user: {
+      email: apiResponse.email || '',
+      gravatar: apiResponse.gravatar || '',
+      name: apiResponse.name || '',
+      username: apiResponse.username
+    }
   };
 }
 
@@ -59,16 +56,14 @@ export function getOpenSRPUserInfo(apiResponse: { [key: string]: any }): Session
   if (!apiResponse.userName) {
     throw new Error(OAUTH2_CALLBACK_ERROR);
   }
-  const user = {
-    email: '',
-    gravatar: '',
-    name: '',
-    username: apiResponse.userName
-  };
-  const extraData = apiResponse;
   return {
     authenticated: true,
-    extraData,
-    user
+    extraData: apiResponse,
+    user: {
+      email: '',
+      gravatar: '',
+      name: '',
+      username: apiResponse.userName
+    }
   };
 }

--- a/packages/gatekeeper/src/helpers/oauth.ts
+++ b/packages/gatekeeper/src/helpers/oauth.ts
@@ -51,3 +51,24 @@ export function getOnadataUserInfo(apiResponse: { [key: string]: any }): Session
     user
   };
 }
+
+/** Function to get OpenSRP user info from api response object
+ * @param {{[key: string]: any }} apiResponse - the API response object
+ */
+export function getOpenSRPUserInfo(apiResponse: { [key: string]: any }): SessionState {
+  if (!apiResponse.userName) {
+    throw new Error(OAUTH2_CALLBACK_ERROR);
+  }
+  const user = {
+    email: '',
+    gravatar: '',
+    name: '',
+    username: apiResponse.userName
+  };
+  const extraData = apiResponse;
+  return {
+    authenticated: true,
+    extraData,
+    user
+  };
+}

--- a/packages/gatekeeper/src/helpers/services.ts
+++ b/packages/gatekeeper/src/helpers/services.ts
@@ -67,9 +67,15 @@ export async function fetchUser(
   method: HTTPMethod = 'GET'
 ) {
   try {
-    const userInfo = await oauth2Callback(locationHash, url, provider, userInfoCallback, method);
-    if (userInfo) {
-      const { authenticated, user, extraData } = userInfo;
+    const responseInfo = await oauth2Callback(
+      locationHash,
+      url,
+      provider,
+      userInfoCallback,
+      method
+    );
+    if (responseInfo) {
+      const { authenticated, user, extraData } = responseInfo;
       authenticateActionCreator(authenticated, user, extraData);
       recordResultActionCreator(true, extraData);
     } else {

--- a/packages/gatekeeper/src/helpers/tests/fixtures.ts
+++ b/packages/gatekeeper/src/helpers/tests/fixtures.ts
@@ -19,6 +19,14 @@ export const onadataUser = {
   website: ''
 };
 
+export const oAuth2Data = {
+  access_token: 'iLoveOov',
+  expires_in: '36000',
+  scope: 'read write',
+  state: 'abc',
+  token_type: 'Bearer'
+};
+
 export const finalExtraData = {
   api_token: 'the api token',
   city: '',
@@ -27,13 +35,7 @@ export const finalExtraData = {
   gravatar:
     'https://secure.gravatar.com/avatar/ae22ab897231db07205bd5d00e64cbbf?d=https%3A%2F%2Fona.io%2Fstatic%2Fimages%2Fdefault_avatar.png&s=60',
   name: 'mosh',
-  oAuth2Data: {
-    access_token: 'iLoveOov',
-    expires_in: '36000',
-    scope: 'read write',
-    state: 'abc',
-    token_type: 'Bearer'
-  },
+  oAuth2Data,
   organization: '',
   require_auth: true,
   temp_token: 'the temp token',
@@ -73,5 +75,27 @@ export const onadataSessionWithOauthData = {
     gravatar: onadataUser.gravatar,
     name: onadataUser.name,
     username: onadataUser.username
+  }
+};
+
+export const openSRPResponse = {
+  preferredName: 'mosh',
+  roles: ['Privilege Level: Full'],
+  userName: 'moshthepitt'
+};
+
+export const openSRPFinalData = {
+  ...openSRPResponse,
+  oAuth2Data
+};
+
+export const openSRPSession = {
+  authenticated: true,
+  extraData: openSRPFinalData,
+  user: {
+    email: '',
+    gravatar: '',
+    name: '',
+    username: openSRPResponse.userName
   }
 };

--- a/packages/gatekeeper/src/helpers/tests/oauth.test.ts
+++ b/packages/gatekeeper/src/helpers/tests/oauth.test.ts
@@ -1,4 +1,9 @@
-import { getOnadataUserInfo, getProviderFromOptions, Providers } from '../oauth';
+import {
+  getOnadataUserInfo,
+  getOpenSRPUserInfo,
+  getProviderFromOptions,
+  Providers
+} from '../oauth';
 import * as fixtures from './fixtures';
 
 describe('gatekeeper/oAuth', () => {
@@ -26,5 +31,9 @@ describe('gatekeeper/oAuth', () => {
     expect(getOnadataUserInfo(fixtures.finalExtraData)).toEqual(
       fixtures.onadataSessionWithOauthData
     );
+  });
+
+  it('getOpenSRPUserInfo should work', async () => {
+    expect(getOpenSRPUserInfo(fixtures.openSRPFinalData)).toEqual(fixtures.openSRPSession);
   });
 });

--- a/packages/gatekeeper/src/index.ts
+++ b/packages/gatekeeper/src/index.ts
@@ -28,6 +28,7 @@ import gateKeeperReducer, {
 
 import {
   getOnadataUserInfo,
+  getOpenSRPUserInfo,
   getProviderFromOptions,
   OauthOptions,
   Providers,
@@ -46,6 +47,7 @@ export {
   gateKeeperReducer,
   gateKeeperReducerName,
   getOnadataUserInfo,
+  getOpenSRPUserInfo,
   getProviderFromOptions,
   getResult,
   getSuccess,


### PR DESCRIPTION
This PR adds a method that gets user information from an OpenSRP server, meant to be used during the oAuth process.

