### PR TITLE
Reducer Registry: Preserve all initial state

### DIFF
--- a/packages/reducer-registry/dist/index.js
+++ b/packages/reducer-registry/dist/index.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "Registry", {
 Object.defineProperty(exports, "store", {
   enumerable: true,
   get: function get() {
-    return _store.default;
+    return _store["default"];
   }
 });
 Object.defineProperty(exports, "combine", {
@@ -29,11 +29,11 @@ Object.defineProperty(exports, "getStore", {
     return _store.getStore;
   }
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _registry = _interopRequireWildcard(require("./registry"));
 
 var _store = _interopRequireWildcard(require("./store"));
 
-var _default = _registry.default;
-exports.default = _default;
+var _default = _registry["default"];
+exports["default"] = _default;

--- a/packages/reducer-registry/dist/registry.js
+++ b/packages/reducer-registry/dist/registry.js
@@ -5,9 +5,7 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.ReducerRegistry = void 0;
-
-var _objectSpread3 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
+exports["default"] = exports.ReducerRegistry = void 0;
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
 
@@ -15,24 +13,28 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/creat
 
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
 var ReducerRegistry = function () {
   function ReducerRegistry() {
-    (0, _classCallCheck2.default)(this, ReducerRegistry);
-    (0, _defineProperty2.default)(this, "emitChange", void 0);
-    (0, _defineProperty2.default)(this, "reducers", void 0);
+    (0, _classCallCheck2["default"])(this, ReducerRegistry);
+    (0, _defineProperty2["default"])(this, "emitChange", void 0);
+    (0, _defineProperty2["default"])(this, "reducers", void 0);
     this.emitChange = null;
     this.reducers = {};
   }
 
-  (0, _createClass2.default)(ReducerRegistry, [{
+  (0, _createClass2["default"])(ReducerRegistry, [{
     key: "getReducers",
     value: function getReducers() {
-      return (0, _objectSpread3.default)({}, this.reducers);
+      return _objectSpread({}, this.reducers);
     }
   }, {
     key: "register",
     value: function register(name, reducer) {
-      this.reducers = (0, _objectSpread3.default)({}, this.reducers, (0, _defineProperty2.default)({}, name, reducer));
+      this.reducers = _objectSpread({}, this.reducers, (0, _defineProperty2["default"])({}, name, reducer));
 
       if (this.emitChange !== null) {
         this.emitChange(this.getReducers());
@@ -50,4 +52,4 @@ var ReducerRegistry = function () {
 exports.ReducerRegistry = ReducerRegistry;
 var reducerRegistry = new ReducerRegistry();
 var _default = reducerRegistry;
-exports.default = _default;
+exports["default"] = _default;

--- a/packages/reducer-registry/dist/store.js
+++ b/packages/reducer-registry/dist/store.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.combine = combine;
 exports.getStore = getStore;
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _redux = require("redux");
 
@@ -15,14 +15,11 @@ var _registry = _interopRequireDefault(require("./registry"));
 
 function combine(reducers) {
   var initialState = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  var reducerNames = Object.keys(reducers);
   Object.keys(initialState).forEach(function (item) {
-    if (reducerNames.indexOf(item) === -1) {
-      reducers[item] = function () {
-        var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState[item];
-        return state;
-      };
-    }
+    reducers[item] = function () {
+      var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState[item];
+      return state;
+    };
   });
   return (0, _redux.combineReducers)(reducers);
 }
@@ -39,11 +36,11 @@ function getStore(reducers) {
   });
 }
 
-var store = getStore(_registry.default.getReducers());
+var store = getStore(_registry["default"].getReducers());
 
-_registry.default.setChangeListener(function (reducers) {
+_registry["default"].setChangeListener(function (reducers) {
   store.replaceReducer(combine(reducers));
 });
 
 var _default = store;
-exports.default = _default;
+exports["default"] = _default;

--- a/packages/reducer-registry/dist/types/store.d.ts
+++ b/packages/reducer-registry/dist/types/store.d.ts
@@ -5,8 +5,7 @@ import { Registry } from './registry';
 interface State {
   [key: string]: any;
 }
-/** Combine all reducers, but preserve initial state for not-yet-loaded
- * reducers
+/** Combine all reducers, but preserve any initial state
  */
 export declare function combine(
   reducers: Registry,
@@ -17,7 +16,7 @@ export declare function combine(
   },
   import('redux').AnyAction
 >;
-/** Function that returns a Redux store given a a list of Redicers and initial
+/** Function that returns a Redux store given a list of Reducers and initial
  * state
  */
 export declare function getStore(

--- a/packages/reducer-registry/src/store.ts
+++ b/packages/reducer-registry/src/store.ts
@@ -7,20 +7,16 @@ interface State {
   [key: string]: any;
 }
 
-/** Combine all reducers, but preserve initial state for not-yet-loaded
- * reducers
+/** Combine all reducers, but preserve any initial state
  */
 export function combine(reducers: Registry, initialState: State = {}) {
-  const reducerNames = Object.keys(reducers);
   Object.keys(initialState).forEach(item => {
-    if (reducerNames.indexOf(item) === -1) {
-      reducers[item] = (state = initialState[item]): Reducer => state;
-    }
+    reducers[item] = (state = initialState[item]): Reducer => state;
   });
   return combineReducers(reducers);
 }
 
-/** Function that returns a Redux store given a a list of Redicers and initial
+/** Function that returns a Redux store given a list of Reducers and initial
  * state
  */
 export function getStore(reducers: Registry, initialState: State = {}) {

--- a/packages/reducer-registry/src/tests/registry.test.ts
+++ b/packages/reducer-registry/src/tests/registry.test.ts
@@ -35,11 +35,15 @@ describe('reducer-registry', () => {
   it('should preserve initial state', () => {
     const initialState = {
       things: ['users', 'messages'],
+      users: ['bob', 'tom'],
       x: 1
     };
     reducerRegistry.register('users', users);
+    reducerRegistry.register('messages', messages);
     const newStore = getStore(reducerRegistry.getReducers(), initialState);
     expect(newStore.getState().x).toEqual(1);
     expect(newStore.getState().things).toEqual(['users', 'messages']);
+    expect(newStore.getState().users).toEqual(['bob', 'tom']);
+    expect(newStore.getState().messages).toEqual({ messages: [] });
   });
 });


### PR DESCRIPTION
This is needed for our work here https://github.com/onaio/reveal-frontend/issues/156

We need to be able to provide initial state that is retained, but currently any initial state is lost when a package is registered.  This fixes that.