### PR TITLE
connected-reducer-registry: Add support for iniitial state in getConnectedStore

### DIFF
--- a/packages/connected-reducer-registry/dist/index.js
+++ b/packages/connected-reducer-registry/dist/index.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.getConnectedStore = getConnectedStore;
-exports.default = exports.connectReducer = exports.history = void 0;
+exports["default"] = exports.connectReducer = exports.history = void 0;
 
 var _reduxReducerRegistry = _interopRequireWildcard(require("@onaio/redux-reducer-registry"));
 
@@ -24,12 +24,13 @@ var history = (0, _history.createBrowserHistory)();
 exports.history = history;
 
 function getConnectedStore(reducers) {
+  var initialState = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   Object.keys(reducers).forEach(function (reducerName) {
-    _reduxReducerRegistry.default.register(reducerName, reducers[reducerName]);
+    _reduxReducerRegistry["default"].register(reducerName, reducers[reducerName]);
   });
-  var reducer = (0, _reduxReducerRegistry.combine)(_reduxReducerRegistry.default.getReducers());
+  var reducer = (0, _reduxReducerRegistry.combine)(_reduxReducerRegistry["default"].getReducers(), initialState);
   var composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || _redux.compose;
-  return (0, _redux.createStore)(reducer, composeEnhancers((0, _redux.applyMiddleware)(_reduxThunk.default, (0, _connectedReactRouter.routerMiddleware)(history))));
+  return (0, _redux.createStore)(reducer, initialState, composeEnhancers((0, _redux.applyMiddleware)(_reduxThunk["default"], (0, _connectedReactRouter.routerMiddleware)(history))));
 }
 
 var connectReducer = (0, _connectedReactRouter.connectRouter)(history);
@@ -39,9 +40,9 @@ var defaultReducers = {
 };
 var store = getConnectedStore(defaultReducers);
 
-_reduxReducerRegistry.default.setChangeListener(function (reducers) {
+_reduxReducerRegistry["default"].setChangeListener(function (reducers) {
   store.replaceReducer((0, _reduxReducerRegistry.combine)(reducers));
 });
 
 var _default = store;
-exports.default = _default;
+exports["default"] = _default;

--- a/packages/connected-reducer-registry/dist/types/index.d.ts
+++ b/packages/connected-reducer-registry/dist/types/index.d.ts
@@ -6,13 +6,19 @@ declare global {
     __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
   }
 }
+/** Declare type for initial state */
+interface State {
+  [key: string]: any;
+}
 /** Create the browser history object */
 export declare const history: import('history').History<any>;
 /** Function to create the connected Redux Registry store
  * @param {Registry} reducers - The default reducers to include in the store.
+ * @param {State} initialState - The initial state.
  */
 export declare function getConnectedStore(
-  reducers: Registry
+  reducers: Registry,
+  initialState?: State
 ): import('redux').Store<
   {
     [x: string]: any;

--- a/packages/connected-reducer-registry/src/index.ts
+++ b/packages/connected-reducer-registry/src/index.ts
@@ -11,26 +11,36 @@ declare global {
   }
 }
 
+/** Declare type for initial state */
+interface State {
+  [key: string]: any;
+}
+
 /** Create the browser history object */
 export const history = createBrowserHistory();
 
 /** Function to create the connected Redux Registry store
  * @param {Registry} reducers - The default reducers to include in the store.
+ * @param {State} initialState - The initial state.
  */
-export function getConnectedStore(reducers: Registry) {
+export function getConnectedStore(reducers: Registry, initialState: State = {}) {
   /** Register each of the initial reducers */
   Object.keys(reducers).forEach(reducerName => {
     reducerRegistry.register(reducerName, reducers[reducerName]);
   });
 
   /** Combine reducers */
-  const reducer = combine(reducerRegistry.getReducers());
+  const reducer = combine(reducerRegistry.getReducers(), initialState);
 
   /** Add redux dev tools to enhancers */
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
   /** Create the store */
-  return createStore(reducer, composeEnhancers(applyMiddleware(thunk, routerMiddleware(history))));
+  return createStore(
+    reducer,
+    initialState,
+    composeEnhancers(applyMiddleware(thunk, routerMiddleware(history)))
+  );
 }
 
 /** Router reducer */

--- a/packages/connected-reducer-registry/src/tests/index.test.ts
+++ b/packages/connected-reducer-registry/src/tests/index.test.ts
@@ -44,6 +44,14 @@ describe('store', () => {
     expect(selectAllMessages(store.getState())).toEqual([{ message: 'hello', user: 'bob' }]);
   });
 
+  it('should be able to work with initial state', () => {
+    reducerRegistry.register('messages', messages);
+    const newStore = getConnectedStore(reducerRegistry.getReducers(), {
+      messages: [{ foo: 'bar' }]
+    });
+    expect(newStore.getState().messages).toEqual([{ foo: 'bar' }]);
+  });
+
   it('should be able to create a connected store', () => {
     /** create default reducers */
     const defaultReducers = {};


### PR DESCRIPTION
This is needed for our work here onaio/reveal-frontend#156 and is related to #111 

We need to be able to provide initial state that is retained. This fixes that.