### PR TITLE
Fix broken lint tests

### DIFF
--- a/packages/cbv/src/Base.tsx
+++ b/packages/cbv/src/Base.tsx
@@ -83,10 +83,7 @@ export abstract class Base<ActionType, SelectorType, PropsType, RootState = Regi
     /** map state to props */
     const mapStateToProps = this.getMapStateToProps();
     /** connect to store */
-    return connect(
-      mapStateToProps,
-      mapDispatchToProps
-    )(this.getHOC());
+    return connect(mapStateToProps, mapDispatchToProps)(this.getHOC());
   }
 
   /**

--- a/packages/cbv/src/tests/ObjectList.test.tsx
+++ b/packages/cbv/src/tests/ObjectList.test.tsx
@@ -65,7 +65,10 @@ describe('cbv/ObjectList', () => {
     store.dispatch(sendMessage({ user: 'bobbie', message: 'hello hello' }));
 
     expect(mapStateToProps(store.getState(), {} as any)).toEqual({
-      messages: [{ user: 'bob', message: 'hello' }, { user: 'bobbie', message: 'hello hello' }]
+      messages: [
+        { user: 'bob', message: 'hello' },
+        { user: 'bobbie', message: 'hello hello' }
+      ]
     });
   });
 
@@ -112,7 +115,10 @@ describe('cbv/ObjectList', () => {
 
       const expected = {
         actionCreator: sendMessage,
-        messages: [{ user: 'bob', message: 'hello' }, { user: 'bobbie', message: 'hello hello' }],
+        messages: [
+          { user: 'bob', message: 'hello' },
+          { user: 'bobbie', message: 'hello hello' }
+        ],
         objectList: []
       };
 


### PR DESCRIPTION
These changes are necessary for our lint test to pass.

This became necessary when we updated our packages before merging the CBV branch to master.  The updated packages led to this failing lint test.