### PR TITLE
[FIX] Refactor getOpenSRPUserInfo helper function to use username

### DIFF
--- a/packages/gatekeeper/dist/helpers/oauth.js
+++ b/packages/gatekeeper/dist/helpers/oauth.js
@@ -48,7 +48,7 @@ function getOnadataUserInfo(apiResponse) {
 }
 
 function getOpenSRPUserInfo(apiResponse) {
-  if (!apiResponse.userName) {
+  if (!apiResponse.username) {
     throw new Error(_constants.OAUTH2_CALLBACK_ERROR);
   }
 
@@ -59,7 +59,7 @@ function getOpenSRPUserInfo(apiResponse) {
       email: '',
       gravatar: '',
       name: '',
-      username: apiResponse.userName
+      username: apiResponse.username
     }
   };
 }

--- a/packages/gatekeeper/src/helpers/oauth.ts
+++ b/packages/gatekeeper/src/helpers/oauth.ts
@@ -53,7 +53,7 @@ export function getOnadataUserInfo(apiResponse: { [key: string]: any }): Session
  * @param {{[key: string]: any }} apiResponse - the API response object
  */
 export function getOpenSRPUserInfo(apiResponse: { [key: string]: any }): SessionState {
-  if (!apiResponse.userName) {
+  if (!apiResponse.username) {
     throw new Error(OAUTH2_CALLBACK_ERROR);
   }
   return {
@@ -63,7 +63,7 @@ export function getOpenSRPUserInfo(apiResponse: { [key: string]: any }): Session
       email: '',
       gravatar: '',
       name: '',
-      username: apiResponse.userName
+      username: apiResponse.username
     }
   };
 }

--- a/packages/gatekeeper/src/helpers/tests/fixtures.ts
+++ b/packages/gatekeeper/src/helpers/tests/fixtures.ts
@@ -81,7 +81,7 @@ export const onadataSessionWithOauthData = {
 export const openSRPResponse = {
   preferredName: 'mosh',
   roles: ['Privilege Level: Full'],
-  userName: 'moshthepitt'
+  username: 'moshthepitt'
 };
 
 export const openSRPFinalData = {
@@ -96,7 +96,7 @@ export const openSRPSession = {
     email: '',
     gravatar: '',
     name: '',
-    username: openSRPResponse.userName
+    username: openSRPResponse.username
   }
 };
 


### PR DESCRIPTION
This change affects only the getOpenSRPUserInfo helper function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/onaio/js-tools#contribution-guidelines
-->

**closes #**
Issue was not created.

<!-- What issue does this pr close -->

**Changes included with this PR**
- Refactor getOpenSRPUserInfo helper function to use `username` property value of the apiResponse argument as opposed to `userName` 

<!--
list of non-trivial changes included with the PR
-->

**Checklist**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are included and passing
- [ ] documentation is changed or added
- [x] a .storybook story was added where necessary.(not necessary)
- [x] code is [transpiled](https://github.com/onaio/js-tools#transpiling-the-package-and-generating-type-definations-for-it)
