### PR TITLE
Solve bug drilldown pagination number not editing

### DIFF
--- a/packages/DrillDownTable/dist/components/Pagination/index.js
+++ b/packages/DrillDownTable/dist/components/Pagination/index.js
@@ -56,14 +56,16 @@ function Pagination(props) {
   };
 
   var onChangePageIndex = function onChangePageIndex(e) {
-    setPageNumber(e.target.value);
+    var newPageNumber = e.target.value;
 
     if (e.target.value) {
       var value = Number(e.target.value);
       var index = value ? pageOptions.indexOf(value - 1) >= 0 ? value - 1 : 0 : 0;
       gotoPage(index);
-      setPageNumber("".concat(index + 1));
+      newPageNumber = "".concat(index + 1);
     }
+
+    setPageNumber(newPageNumber);
   };
 
   var onClickNext = function onClickNext() {

--- a/packages/DrillDownTable/dist/components/Pagination/index.js
+++ b/packages/DrillDownTable/dist/components/Pagination/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
 Object.defineProperty(exports, "__esModule", {
@@ -8,7 +10,9 @@ Object.defineProperty(exports, "__esModule", {
 exports.RevealPagination = Pagination;
 exports.renderPaginationFun = void 0;
 
-var _react = _interopRequireDefault(require("react"));
+var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
+
+var _react = _interopRequireWildcard(require("react"));
 
 var _constants = require("../../helpers/constants");
 
@@ -34,6 +38,15 @@ function Pagination(props) {
       pageIndex = _props$state.pageIndex,
       pageSizeCategories = props.pageSizeCategories;
 
+  var _useState = (0, _react.useState)(''),
+      _useState2 = (0, _slicedToArray2["default"])(_useState, 2),
+      pageNumber = _useState2[0],
+      setPageNumber = _useState2[1];
+
+  (0, _react.useEffect)(function () {
+    setPageNumber("".concat(pageIndex + 1));
+  }, [pageIndex]);
+
   var onChangePageSize = function onChangePageSize(e) {
     setPageSize(Number(e.target.value));
   };
@@ -43,8 +56,14 @@ function Pagination(props) {
   };
 
   var onChangePageIndex = function onChangePageIndex(e) {
-    var page = e.target.value ? Number(e.target.value) - 1 : 0;
-    gotoPage(page);
+    setPageNumber(e.target.value);
+
+    if (e.target.value) {
+      var value = Number(e.target.value);
+      var index = value ? pageOptions.indexOf(value - 1) >= 0 ? value - 1 : 0 : 0;
+      gotoPage(index);
+      setPageNumber("".concat(index + 1));
+    }
   };
 
   var onClickNext = function onClickNext() {
@@ -70,7 +89,7 @@ function Pagination(props) {
     disabled: !canPreviousPage
   }, props.previousText), _react["default"].createElement("span", null, props.pageText, " ", '  ', _react["default"].createElement("input", {
     type: "text",
-    value: pageIndex + 1,
+    value: pageNumber,
     onChange: onChangePageIndex,
     style: {
       width: '40px'

--- a/packages/DrillDownTable/src/components/Pagination/index.tsx
+++ b/packages/DrillDownTable/src/components/Pagination/index.tsx
@@ -58,14 +58,16 @@ function Pagination<T extends object = Dictionary>(props: PaginationProps<T>) {
     previousPage();
   };
   const onChangePageIndex = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPageNumber(e.target.value);
+    let newPageNumber = e.target.value;
 
     if (e.target.value) {
       const value = Number(e.target.value);
       const index = value ? (pageOptions.indexOf(value - 1) >= 0 ? value - 1 : 0) : 0;
       gotoPage(index);
-      setPageNumber(`${index + 1}`);
+      newPageNumber = `${index + 1}`;
     }
+
+    setPageNumber(newPageNumber);
   };
   const onClickNext = () => {
     nextPage();

--- a/packages/DrillDownTable/src/components/Pagination/index.tsx
+++ b/packages/DrillDownTable/src/components/Pagination/index.tsx
@@ -1,6 +1,6 @@
 /** The default custom pagination component for drillDown v7  */
 import { Dictionary } from '@onaio/utils';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   NEXT,
   OF,
@@ -45,6 +45,12 @@ function Pagination<T extends object = Dictionary>(props: PaginationProps<T>) {
     pageSizeCategories
   } = props;
 
+  const [pageNumber, setPageNumber] = useState<string>('');
+
+  useEffect(() => {
+    setPageNumber(`${pageIndex + 1}`);
+  }, [pageIndex]);
+
   const onChangePageSize = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setPageSize(Number(e.target.value));
   };
@@ -52,8 +58,14 @@ function Pagination<T extends object = Dictionary>(props: PaginationProps<T>) {
     previousPage();
   };
   const onChangePageIndex = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const page = e.target.value ? Number(e.target.value) - 1 : 0;
-    gotoPage(page);
+    setPageNumber(e.target.value);
+
+    if (e.target.value) {
+      const value = Number(e.target.value);
+      const index = value ? (pageOptions.indexOf(value - 1) >= 0 ? value - 1 : 0) : 0;
+      gotoPage(index);
+      setPageNumber(`${index + 1}`);
+    }
   };
   const onClickNext = () => {
     nextPage();
@@ -76,7 +88,7 @@ function Pagination<T extends object = Dictionary>(props: PaginationProps<T>) {
         {props.pageText} {'  '}
         <input
           type="text"
-          value={pageIndex + 1}
+          value={pageNumber}
           onChange={onChangePageIndex}
           style={{ width: '40px' }}
         />{' '}

--- a/packages/DrillDownTable/src/components/Pagination/tests/index.test.tsx
+++ b/packages/DrillDownTable/src/components/Pagination/tests/index.test.tsx
@@ -3,19 +3,55 @@ import React from 'react';
 import { renderPaginationFun } from '..';
 /** integration tests reside will reside in the drilldown's test folder */
 describe('src/components/Table/Drilldown/helpers/pagination', () => {
+  const props = {
+    canNextPage: true,
+    canPreviousPage: false,
+    gotoPage: jest.fn(),
+    nextPage: jest.fn(),
+    pageOptions: [0, 1, 2, 3, 4, 5],
+    previousPage: jest.fn(),
+    setPageSize: jest.fn(),
+    state: {
+      pageIndex: 0,
+      pageSize: 20
+    }
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
   it('renders without crashing', () => {
-    const props = {
-      canNextPage: true,
-      canPreviousPage: false,
-      nextPage: jest.fn(),
-      pageOptions: { length: 20 },
-      previousPage: jest.fn(),
-      setPageSize: jest.fn(),
-      state: {
-        pageIndex: 0,
-        pageSize: 20
-      }
-    };
     mount(<>{renderPaginationFun(props as any)}</>);
+  });
+
+  it('updates page number input correctly', () => {
+    const wrapper = mount(<>{renderPaginationFun(props as any)}</>);
+    // Initialized to 1
+    expect(wrapper.find('input').props().value).toEqual('1');
+    wrapper.find('input').simulate('change', { target: { value: '2' } });
+    wrapper.update();
+    expect(props.gotoPage).toHaveBeenCalledWith(1);
+    expect(wrapper.find('input').props().value).toEqual('2');
+  });
+
+  it('renders page 1 if page input is invalid', () => {
+    const wrapper = mount(<>{renderPaginationFun(props as any)}</>);
+    // Test page number above max number
+    wrapper.find('input').simulate('change', { target: { value: '7' } });
+    wrapper.update();
+    expect(props.gotoPage).toHaveBeenCalledWith(0);
+    expect(wrapper.find('input').props().value).toEqual('1');
+    // Test negative number
+    wrapper.find('input').simulate('change', { target: { value: '-1' } });
+    wrapper.update();
+    expect(props.gotoPage).toHaveBeenCalledWith(0);
+    expect(wrapper.find('input').props().value).toEqual('1');
+    // Test string
+    wrapper.find('input').simulate('change', { target: { value: 'hello world' } });
+    wrapper.update();
+    expect(props.gotoPage).toHaveBeenCalledWith(0);
+    expect(wrapper.find('input').props().value).toEqual('1');
   });
 });


### PR DESCRIPTION
closes https://github.com/onaio/reveal-frontend/issues/851

Updated the `Pagination` component input to be controlled and read its value from state. When the input changes, the value is updated accordingly. 
Enhanced to render the first page if the input is invalid 



