### PR TITLE
Set Colors when Line Color Threshold is not Defined

### DIFF
--- a/packages/ProgressIndicators/src/ProgressBar/index.tsx
+++ b/packages/ProgressIndicators/src/ProgressBar/index.tsx
@@ -40,6 +40,23 @@ export const defaultProgressBarProps: Partial<ProgressBarProps> = {
   value: 0
 };
 
+export function getColor(lineColorThresholds, percentValue) {
+  const ascendingThresholds = Object.keys(lineColorThresholds).sort(
+    (e1, e2) => lineColorThresholds[e1].value - lineColorThresholds[e2].value
+  );
+
+  // top to bottom check to see which color threshold is matched first by the percentValue
+  for (const item of ascendingThresholds) {
+    if (
+      lineColorThresholds[item].orEquals
+        ? percentValue <= lineColorThresholds[item].value * 100
+        : percentValue < lineColorThresholds[item].value * 100
+    ) {
+      return lineColorThresholds[item].color;
+    }
+  }
+}
+
 /** Displays configurable progress bar */
 class ProgressBar extends Component<ProgressBarProps, {}> {
   public static defaultProps = defaultProgressBarProps;
@@ -54,13 +71,12 @@ class ProgressBar extends Component<ProgressBarProps, {}> {
       animate,
       decimalPoints,
       value,
-      lineColor,
       cssClass,
       stripped,
       lineColorThresholds,
       showLabel
     } = props;
-    let backgroundColor = lineColor;
+
     const max = props.max || 100;
     const min = props.min || 0;
     let range = max - min;

--- a/packages/ProgressIndicators/src/ProgressBar/index.tsx
+++ b/packages/ProgressIndicators/src/ProgressBar/index.tsx
@@ -1,6 +1,10 @@
 import { Color } from 'csstype';
 import React, { Component } from 'react';
 
+export const GREEN_THRESHOLD = 0.9;
+export const YELLOW_THRESHOLD = 0.2;
+export const ORANGE_THRESHOLD = 0.8;
+
 export interface IndicatorThresholdItem {
   color: Color;
   name: string;

--- a/packages/ProgressIndicators/src/ProgressBar/index.tsx
+++ b/packages/ProgressIndicators/src/ProgressBar/index.tsx
@@ -20,7 +20,6 @@ export interface ProgressBarProps {
   min: number /** set lower bound for the progressBar range */;
   max: number /** set upper bound for the progressBar range */;
   value: number /** Represents the progress bar value */;
-  lineColor: string /** set line colors */;
   lineColorThresholds?: { [key: string]: IndicatorThresholdItem } /** set linecolor threshold */;
   cssClass: string /** sets css gradient over progressBar */;
   showLabel: boolean /** set label on progressBar */;
@@ -33,7 +32,6 @@ export const defaultProgressBarProps: Partial<ProgressBarProps> = {
   cssClass: 'progress-bar-striped',
   decimalPoints: 0,
   height: '10px',
-  lineColor: '#0000FF',
   lineColorThresholds: undefined,
   max: 100,
   min: 0,

--- a/packages/ProgressIndicators/src/ProgressBar/index.tsx
+++ b/packages/ProgressIndicators/src/ProgressBar/index.tsx
@@ -87,25 +87,15 @@ class ProgressBar extends Component<ProgressBarProps, {}> {
     const percentValue = decimalValue * 100;
     const percentValueString = percentValue.toFixed(decimalPoints);
 
-    // set the line color: if lineColorThresholds is not given; lineColor will be used
-    if (lineColorThresholds) {
-      // sort the color and their thresholds by the threshold value
-      const ascendingThresholds = Object.keys(lineColorThresholds).sort(
-        (e1, e2) => lineColorThresholds[e1].value - lineColorThresholds[e2].value
-      );
-
-      // top to bottom check to see which color threshold is matched first by the percentValue
-      for (const item of ascendingThresholds) {
-        if (
-          lineColorThresholds[item].orEquals
-            ? percentValue <= lineColorThresholds[item].value * 100
-            : percentValue < lineColorThresholds[item].value * 100
-        ) {
-          backgroundColor = lineColorThresholds[item].color;
-          break;
-        }
-      }
-    }
+    const backgroundColor = lineColorThresholds
+      ? getColor(lineColorThresholds, percentValue)
+      : decimalValue >= GREEN_THRESHOLD
+      ? '#33ad33'
+      : decimalValue >= ORANGE_THRESHOLD
+      ? '#ff8533'
+      : decimalValue >= YELLOW_THRESHOLD
+      ? '#ff5c33'
+      : '#ff3';
 
     return (
       <div className="progress">


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/onaio/js-tools#contribution-guidelines
-->

**closes #**

<!-- What issue does this pr close -->
Instead of using `lineColor` props, we use the value to set background color when lineColorThreshold is not defined
**Changes included with this PR**

<!--
list of non-trivial changes included with the PR
-->

**Checklist**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are included and passing
- [ ] documentation is changed or added
- [ ] a .storybook story was added where necessary.
- [ ] code is [transpiled](https://github.com/onaio/js-tools#transpiling-the-package-and-generating-type-definations-for-it)
