### PR TITLE
Gatekeeper oauth callback bug fix

### DIFF
--- a/packages/gatekeeper/dist/components/callback/implicit.js
+++ b/packages/gatekeeper/dist/components/callback/implicit.js
@@ -58,7 +58,7 @@ var OauthCallback = function OauthCallback(props) {
       recordResultActionCreator = props.recordResultActionCreator,
       sessionData = props.sessionData,
       sessionUser = props.sessionUser;
-  var locationHash = window.location.href;
+  var locationHash = props.location.hash;
   var id = props.match.params.id;
 
   var parsedParams = _queryString["default"].parse(location.search);
@@ -74,11 +74,13 @@ var OauthCallback = function OauthCallback(props) {
   }
 
   var providerOptions = providers[id];
-  var userUri = providerOptions.userUri;
+  var userUri = providerOptions.userUri,
+      redirectUri = providerOptions.redirectUri;
   var provider = (0, _oauth.getProviderFromOptions)(providerOptions);
+  var urlObject = new URL(locationHash, redirectUri);
   (0, _react.useEffect)(function () {
     if (authSuccess === null || authenticated === false) {
-      (0, _services.fetchUser)(locationHash, userUri, provider, authenticateActionCreator, recordResultActionCreator, oAuthUserInfoGetter)["catch"](function (e) {});
+      (0, _services.fetchUser)(urlObject, userUri, provider, authenticateActionCreator, recordResultActionCreator, oAuthUserInfoGetter)["catch"](function (e) {});
     }
   }, []);
   var baseProps = {

--- a/packages/gatekeeper/dist/components/callback/implicit.js
+++ b/packages/gatekeeper/dist/components/callback/implicit.js
@@ -58,7 +58,7 @@ var OauthCallback = function OauthCallback(props) {
       recordResultActionCreator = props.recordResultActionCreator,
       sessionData = props.sessionData,
       sessionUser = props.sessionUser;
-  var locationHash = props.location.hash;
+  var locationHash = window.location.href;
   var id = props.match.params.id;
 
   var parsedParams = _queryString["default"].parse(location.search);

--- a/packages/gatekeeper/dist/helpers/services.js
+++ b/packages/gatekeeper/dist/helpers/services.js
@@ -28,7 +28,7 @@ function oauth2Callback(_x, _x2, _x3, _x4) {
 }
 
 function _oauth2Callback() {
-  _oauth2Callback = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee3(locationHash, url, provider, userInfoCallback) {
+  _oauth2Callback = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee3(urlObject, url, provider, userInfoCallback) {
     var method,
         _args3 = arguments;
     return _regenerator["default"].wrap(function _callee3$(_context3) {
@@ -36,7 +36,7 @@ function _oauth2Callback() {
         switch (_context3.prev = _context3.next) {
           case 0:
             method = _args3.length > 4 && _args3[4] !== undefined ? _args3[4] : 'GET';
-            return _context3.abrupt("return", provider.token.getToken(locationHash).then(function () {
+            return _context3.abrupt("return", provider.token.getToken(urlObject).then(function () {
               var _ref3 = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee2(oAuthObject) {
                 var response, data;
                 return _regenerator["default"].wrap(function _callee2$(_context2) {
@@ -96,7 +96,7 @@ function fetchUser(_x5, _x6, _x7) {
 }
 
 function _fetchUser() {
-  _fetchUser = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee4(locationHash, url, provider) {
+  _fetchUser = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee4(urlObject, resourceUrl, provider) {
     var authenticateActionCreator,
         recordResultActionCreator,
         userInfoCallback,
@@ -118,7 +118,7 @@ function _fetchUser() {
             method = _args4.length > 7 && _args4[7] !== undefined ? _args4[7] : 'GET';
             _context4.prev = 5;
             _context4.next = 8;
-            return oauth2Callback(locationHash, url, provider, userInfoCallback, method);
+            return oauth2Callback(urlObject, resourceUrl, provider, userInfoCallback, method);
 
           case 8:
             responseInfo = _context4.sent;

--- a/packages/gatekeeper/dist/types/helpers/services.d.ts
+++ b/packages/gatekeeper/dist/types/helpers/services.d.ts
@@ -14,7 +14,7 @@ declare type HTTPMethod = 'GET' | 'POST' | 'get' | 'post';
  * @param {string} method - the HTTP method to use
  */
 export declare function oauth2Callback(
-  locationHash: string,
+  urlObject: URL,
   url: string,
   provider: ClientOAuth2,
   userInfoCallback: UserInfoFnType,
@@ -32,8 +32,8 @@ export declare function oauth2Callback(
  * @param {string} method - the HTTP method to use
  */
 export declare function fetchUser(
-  locationHash: string,
-  url: string,
+  urlObject: URL,
+  resourceUrl: string,
   provider: ClientOAuth2,
   authenticateActionCreator?: ActionCreator<AuthenticateAction>,
   recordResultActionCreator?: ActionCreator<RecordAction>,

--- a/packages/gatekeeper/dist/types/helpers/services.d.ts
+++ b/packages/gatekeeper/dist/types/helpers/services.d.ts
@@ -7,7 +7,7 @@ import { ErrorCallback } from './utils';
 /** allowed http methods */
 declare type HTTPMethod = 'GET' | 'POST' | 'get' | 'post';
 /** Calls the oAuth provider to get user details
- * @param {string} locationHash - the location hash value that we receive from the oAuth provider
+ * @param {URL} urlObject - the URL object defined by the location hash and href
  * @param {string} url - the URL that returns the user information for the provider
  * @param {ClientOAuth2} provider - the Oauth client object for the provider
  * @param {UserInfoFnType} userInfoCallback - function the gets user info from API response
@@ -22,7 +22,7 @@ export declare function oauth2Callback(
 ): Promise<void | import('@onaio/session-reducer/dist/types').SessionState>;
 /** This function is used to fetch the user logging in by calling oauth2Callback
  * and then calling authenticateUser to store the user in the Redux store.
- * @param {string} locationHash - the location hash value that we receive from the oAuth provider
+ * @param {URL} urlObject - the URL object defined by the location hash and href
  * @param {string} url - the URL that returns the user information for the provider
  * @param {ClientOAuth2} provider - the Oauth client object for the provider
  * @param {ActionCreator<AuthenticateAction>} authenticateActionCreator - the authenticate action creator function

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@onaio/session-reducer": "^0.0.11",
-    "client-oauth2": "^4.2.3",
+    "client-oauth2": "^4.3.3",
     "query-string": "^6.4.2"
   },
   "devDependencies": {

--- a/packages/gatekeeper/src/components/callback/implicit.tsx
+++ b/packages/gatekeeper/src/components/callback/implicit.tsx
@@ -80,7 +80,7 @@ const OauthCallback = (props: OauthCallbackProps<RouteParams>) => {
     sessionData,
     sessionUser
   } = props;
-  const locationHash = props.location.hash;
+  const locationHref = window.location.href;
   const id = props.match.params.id;
   const parsedParams = qs.parse(location.search);
   const { error } = parsedParams;
@@ -100,7 +100,7 @@ const OauthCallback = (props: OauthCallbackProps<RouteParams>) => {
   useEffect(() => {
     if (authSuccess === null || authenticated === false) {
       fetchUser(
-        locationHash,
+        locationHref,
         userUri,
         provider,
         authenticateActionCreator,

--- a/packages/gatekeeper/src/components/callback/implicit.tsx
+++ b/packages/gatekeeper/src/components/callback/implicit.tsx
@@ -80,7 +80,7 @@ const OauthCallback = (props: OauthCallbackProps<RouteParams>) => {
     sessionData,
     sessionUser
   } = props;
-  const locationHref = window.location.href;
+  const locationHash = props.location.hash;
   const id = props.match.params.id;
   const parsedParams = qs.parse(location.search);
   const { error } = parsedParams;
@@ -94,13 +94,13 @@ const OauthCallback = (props: OauthCallbackProps<RouteParams>) => {
   }
 
   const providerOptions = providers[id];
-  const { userUri } = providerOptions;
+  const { userUri, redirectUri } = providerOptions;
   const provider = getProviderFromOptions(providerOptions);
-
+  const urlObject = new URL(locationHash, redirectUri);
   useEffect(() => {
     if (authSuccess === null || authenticated === false) {
       fetchUser(
-        locationHref,
+        urlObject,
         userUri,
         provider,
         authenticateActionCreator,

--- a/packages/gatekeeper/src/components/callback/tests/implicit.test.tsx
+++ b/packages/gatekeeper/src/components/callback/tests/implicit.test.tsx
@@ -148,10 +148,12 @@ describe('gatekeeper/implicit/OauthCallback', () => {
 
     const { onadataAuth } = helperFixtures;
     const url = 'https://stage-api.ona.io/api/v1/user.json';
-    const href = 'http://localhost/';
+    const hash =
+      '#access_token=iLoveOov&expires_in=36000&token_type=Bearer&scope=read+write&state=abc';
+    const urlObject = new URL(hash, 'https://example.com/oauth/callback/onadata/');
 
     expect(mock).toHaveBeenCalledWith(
-      href,
+      urlObject,
       url,
       onadataAuth,
       authenticateUser,

--- a/packages/gatekeeper/src/components/callback/tests/implicit.test.tsx
+++ b/packages/gatekeeper/src/components/callback/tests/implicit.test.tsx
@@ -148,11 +148,10 @@ describe('gatekeeper/implicit/OauthCallback', () => {
 
     const { onadataAuth } = helperFixtures;
     const url = 'https://stage-api.ona.io/api/v1/user.json';
-    const hash =
-      '#access_token=iLoveOov&expires_in=36000&token_type=Bearer&scope=read+write&state=abc';
+    const href = 'http://localhost/';
 
     expect(mock).toHaveBeenCalledWith(
-      hash,
+      href,
       url,
       onadataAuth,
       authenticateUser,

--- a/packages/gatekeeper/src/components/tests/__snapshots__/login.test.tsx.snap
+++ b/packages/gatekeeper/src/components/tests/__snapshots__/login.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`gatekeeper/OauthLogin renders correct links for Authorization code-authorization grant flow: Authorization code authorization grant 1`] = `
 <a
   className="gatekeeper-btn"
-  href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&scope=read%20write&response_type=code&state=abc"
+  href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&response_type=code&state=abc&scope=read%20write"
 >
   onadata
 </a>
@@ -12,7 +12,7 @@ exports[`gatekeeper/OauthLogin renders correct links for Authorization code-auth
 exports[`gatekeeper/OauthLogin renders correct links for implicit authorization grant flow: implicit authorization grant 1`] = `
 <a
   className="gatekeeper-btn"
-  href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&scope=read%20write&response_type=token&state=abc"
+  href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&response_type=token&state=abc&scope=read%20write"
 >
   onadata
 </a>
@@ -45,7 +45,7 @@ exports[`gatekeeper/OauthLogin renders correctly with no ProviderLinksComponent 
   >
     <a
       className="gatekeeper-btn"
-      href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&scope=read%20write&response_type=token&state=abc"
+      href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&response_type=token&state=abc&scope=read%20write"
     >
       onadata
     </a>

--- a/packages/gatekeeper/src/components/tests/__snapshots__/logout.test.tsx.snap
+++ b/packages/gatekeeper/src/components/tests/__snapshots__/logout.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`gatekeeper/ConnectedLogout renders the ConnectedLogout component when l
   >
     <a
       className="gatekeeper-btn"
-      href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&scope=read%20write&response_type=token&state=abc"
+      href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&response_type=token&state=abc&scope=read%20write"
     >
       onadata
     </a>
@@ -88,7 +88,7 @@ exports[`gatekeeper/ConnectedLogout renders the ConnectedLogout when logged in: 
   >
     <a
       className="gatekeeper-btn"
-      href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&scope=read%20write&response_type=token&state=abc"
+      href="https://stage-api.ona.io/o/authorize/?client_id=hunter2&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback%2Fonadata%2F&response_type=token&state=abc&scope=read%20write"
     >
       onadata
     </a>

--- a/packages/gatekeeper/src/helpers/services.ts
+++ b/packages/gatekeeper/src/helpers/services.ts
@@ -28,18 +28,19 @@ type HTTPMethod = 'GET' | 'POST' | 'get' | 'post';
  * @param {string} method - the HTTP method to use
  */
 export async function oauth2Callback(
-  locationHash: string,
-  url: string,
+  currentURL: URL,
+  resourceUrl: string,
   provider: ClientOAuth2,
   userInfoCallback: UserInfoFnType,
   method: HTTPMethod = 'GET'
 ) {
-  return provider.token.getToken(locationHash).then(async (oAuthObject: any) => {
+  const locationHash1: URL = new URL(currentURL, provider.redirectUri);
+  return provider.token.getToken(locationHash1).then(async (oAuthObject: any) => {
     const response = await fetch(
-      url,
+      resourceUrl,
       oAuthObject.sign({
         method,
-        url
+        resourceUrl
       })
     );
 
@@ -68,8 +69,8 @@ export async function oauth2Callback(
  * @param {string} method - the HTTP method to use
  */
 export async function fetchUser(
-  locationHash: string,
-  url: string,
+  currentURL: URL,
+  resourceUrl: string,
   provider: ClientOAuth2,
   authenticateActionCreator: ActionCreator<AuthenticateAction> = authenticateUser,
   recordResultActionCreator: ActionCreator<RecordAction> = recordResult,
@@ -79,8 +80,8 @@ export async function fetchUser(
 ) {
   try {
     const responseInfo = await oauth2Callback(
-      locationHash,
-      url,
+      currentURL,
+      resourceUrl,
       provider,
       userInfoCallback,
       method

--- a/packages/gatekeeper/src/helpers/services.ts
+++ b/packages/gatekeeper/src/helpers/services.ts
@@ -21,7 +21,7 @@ import { ErrorCallback, errorCallback } from './utils';
 type HTTPMethod = 'GET' | 'POST' | 'get' | 'post';
 
 /** Calls the oAuth provider to get user details
- * @param {string} locationHash - the location hash value that we receive from the oAuth provider
+ * @param {URL} urlObject - the URL object defined by the location hash and href
  * @param {string} url - the URL that returns the user information for the provider
  * @param {ClientOAuth2} provider - the Oauth client object for the provider
  * @param {UserInfoFnType} userInfoCallback - function the gets user info from API response
@@ -58,7 +58,7 @@ export async function oauth2Callback(
 
 /** This function is used to fetch the user logging in by calling oauth2Callback
  * and then calling authenticateUser to store the user in the Redux store.
- * @param {string} locationHash - the location hash value that we receive from the oAuth provider
+ * @param {URL} urlObject - the URL object defined by the location hash and href
  * @param {string} url - the URL that returns the user information for the provider
  * @param {ClientOAuth2} provider - the Oauth client object for the provider
  * @param {ActionCreator<AuthenticateAction>} authenticateActionCreator - the authenticate action creator function

--- a/packages/gatekeeper/src/helpers/services.ts
+++ b/packages/gatekeeper/src/helpers/services.ts
@@ -28,19 +28,18 @@ type HTTPMethod = 'GET' | 'POST' | 'get' | 'post';
  * @param {string} method - the HTTP method to use
  */
 export async function oauth2Callback(
-  currentURL: URL,
-  resourceUrl: string,
+  urlObject: URL,
+  url: string,
   provider: ClientOAuth2,
   userInfoCallback: UserInfoFnType,
   method: HTTPMethod = 'GET'
 ) {
-  const locationHash1: URL = new URL(currentURL, provider.redirectUri);
-  return provider.token.getToken(locationHash1).then(async (oAuthObject: any) => {
+  return provider.token.getToken(urlObject).then(async (oAuthObject: any) => {
     const response = await fetch(
-      resourceUrl,
+      url,
       oAuthObject.sign({
         method,
-        resourceUrl
+        url
       })
     );
 
@@ -69,7 +68,7 @@ export async function oauth2Callback(
  * @param {string} method - the HTTP method to use
  */
 export async function fetchUser(
-  currentURL: URL,
+  urlObject: URL,
   resourceUrl: string,
   provider: ClientOAuth2,
   authenticateActionCreator: ActionCreator<AuthenticateAction> = authenticateUser,
@@ -80,7 +79,7 @@ export async function fetchUser(
 ) {
   try {
     const responseInfo = await oauth2Callback(
-      currentURL,
+      urlObject,
       resourceUrl,
       provider,
       userInfoCallback,

--- a/packages/gatekeeper/src/helpers/tests/services.test.ts
+++ b/packages/gatekeeper/src/helpers/tests/services.test.ts
@@ -19,7 +19,12 @@ describe('gatekeeper/services', () => {
 
     fetchMock.getOnce(url, JSON.stringify(data));
 
-    const response = await oauth2Callback(hash, url, provider, getOnadataUserInfo);
+    const response = await oauth2Callback(
+      new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
+      url,
+      provider,
+      getOnadataUserInfo
+    );
 
     const expectedResponse = fixtures.onadataSessionWithOauthData;
 
@@ -38,7 +43,13 @@ describe('gatekeeper/services', () => {
     const authenticateActionCreatorMock = jest.fn();
     const recordResultActionCreator = jest.fn();
 
-    await fetchUser(hash, url, provider, authenticateActionCreatorMock, recordResultActionCreator);
+    await fetchUser(
+      new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
+      url,
+      provider,
+      authenticateActionCreatorMock,
+      recordResultActionCreator
+    );
 
     expect(authenticateActionCreatorMock).toHaveBeenCalledWith(
       true,
@@ -64,7 +75,13 @@ describe('gatekeeper/services', () => {
     let error;
     const recordResultActionCreator = jest.fn();
     try {
-      await fetchUser(hash, url, provider, jest.fn(), recordResultActionCreator);
+      await fetchUser(
+        new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
+        url,
+        provider,
+        jest.fn(),
+        recordResultActionCreator
+      );
     } catch (e) {
       error = e;
     }
@@ -81,7 +98,13 @@ describe('gatekeeper/services', () => {
     const recordResultActionCreator = jest.fn();
     let error;
     try {
-      await fetchUser(hash, url, provider, jest.fn(), recordResultActionCreator);
+      await fetchUser(
+        new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
+        url,
+        provider,
+        jest.fn(),
+        recordResultActionCreator
+      );
     } catch (e) {
       error = e;
     }

--- a/packages/gatekeeper/src/helpers/tests/services.test.ts
+++ b/packages/gatekeeper/src/helpers/tests/services.test.ts
@@ -16,15 +16,11 @@ describe('gatekeeper/services', () => {
     const url = 'https://stage-api.ona.io/api/v1/user.json';
     const hash =
       '#access_token=iLoveOov&expires_in=36000&token_type=Bearer&scope=read+write&state=abc';
+    const urlObject: URL = new URL(hash, 'http://localhost/oauth/callback/onadata/');
 
     fetchMock.getOnce(url, JSON.stringify(data));
 
-    const response = await oauth2Callback(
-      new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
-      url,
-      provider,
-      getOnadataUserInfo
-    );
+    const response = await oauth2Callback(urlObject, url, provider, getOnadataUserInfo);
 
     const expectedResponse = fixtures.onadataSessionWithOauthData;
 
@@ -37,14 +33,14 @@ describe('gatekeeper/services', () => {
     const url = 'https://stage-api.ona.io/api/v1/user.json';
     const hash =
       '#access_token=iLoveOov&expires_in=36000&token_type=Bearer&scope=read+write&state=abc';
+    const urlObject: URL = new URL(hash, 'http://localhost/oauth/callback/onadata/');
     fetchMock.getOnce('https://stage-api.ona.io/api/v1/user.json', JSON.stringify(data));
-
     // mock authenticateActionCreator
     const authenticateActionCreatorMock = jest.fn();
     const recordResultActionCreator = jest.fn();
 
     await fetchUser(
-      new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
+      urlObject,
       url,
       provider,
       authenticateActionCreatorMock,
@@ -71,17 +67,12 @@ describe('gatekeeper/services', () => {
     const url = 'https://stage-api.ona.io/api/v1/user.json';
     const hash =
       '#access_token=iLoveOov&expires_in=36000&token_type=Bearer&scope=read+write&state=abc';
+    const urlObject: URL = new URL(hash, 'http://localhost/oauth/callback/onadata/');
     fetchMock.getOnce('https://stage-api.ona.io/api/v1/user.json', 500);
     let error;
     const recordResultActionCreator = jest.fn();
     try {
-      await fetchUser(
-        new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
-        url,
-        provider,
-        jest.fn(),
-        recordResultActionCreator
-      );
+      await fetchUser(urlObject, url, provider, jest.fn(), recordResultActionCreator);
     } catch (e) {
       error = e;
     }
@@ -94,17 +85,12 @@ describe('gatekeeper/services', () => {
     const url = 'https://stage-api.ona.io/api/v1/user.json';
     const hash =
       '#access_token=iLoveOov&expires_in=36000&token_type=Bearer&scope=read+write&state=abc';
+    const urlObject: URL = new URL(hash, 'http://localhost/oauth/callback/onadata/');
     fetchMock.getOnce('https://stage-api.ona.io/api/v1/user.json', {});
     const recordResultActionCreator = jest.fn();
     let error;
     try {
-      await fetchUser(
-        new URL(hash, 'http://localhost/oauth/callback/onadata/') as any,
-        url,
-        provider,
-        jest.fn(),
-        recordResultActionCreator
-      );
+      await fetchUser(urlObject, url, provider, jest.fn(), recordResultActionCreator);
     } catch (e) {
       error = e;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5175,13 +5175,13 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-client-oauth2@^4.2.3:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/client-oauth2/-/client-oauth2-4.2.5.tgz#cee9499ef0acc84ee545a76a8a51942ddf26f473"
-  integrity sha512-GAhVLveAbBkwcfEH/d5lTW9eCgcPR3Up93cx7v4qWTdLCa4O0m3ykNNn4aAVeWOiHfWL5skO+3u0F/gfAxZuPQ==
+client-oauth2@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/client-oauth2/-/client-oauth2-4.3.3.tgz#7a700e6f4bf412c1f96da0d6b50e07676561e086"
+  integrity sha512-k8AvUYJon0vv75ufoVo4nALYb/qwFFicO3I0+39C6xEdflqVtr+f9cy+0ZxAduoVSTfhP5DX2tY2XICAd5hy6Q==
   dependencies:
-    popsicle "12.0.4"
-    safe-buffer "^5.1.1"
+    popsicle "^12.0.5"
+    safe-buffer "^5.2.0"
 
 clipboard@^2.0.0:
   version "2.0.6"
@@ -11459,20 +11459,20 @@ popsicle-cookie-jar@^1.0.0:
     "@types/tough-cookie" "^2.3.5"
     tough-cookie "^3.0.1"
 
-popsicle-redirects@^1.0.0:
+popsicle-redirects@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/popsicle-redirects/-/popsicle-redirects-1.1.0.tgz#2a5abb49a7ad49c02e90b24d4608dc0b8b23176a"
   integrity sha512-XCpzVjVk7tty+IJnSdqWevmOr1n8HNDhL86v7mZ6T1JIIf2KGybxUk9mm7ZFOhWMkGB0e8XkacHip7BV8AQWQA==
 
-popsicle-transport-http@^1.0.0:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/popsicle-transport-http/-/popsicle-transport-http-1.0.7.tgz#a20bf0dd3a42d4acd55fb9cf34e8cff47789ba49"
-  integrity sha512-UVpbAfJn9Z19A84WdIklHzbK8EHt7o1w0u6JEkAx6BTlkSxI6T2Lo5Vr989YO8pPmbFZhNClz3Eir8fldAYWpQ==
+popsicle-transport-http@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/popsicle-transport-http/-/popsicle-transport-http-1.0.8.tgz#634ba7529aa7715333cdc7c19bc6ca244736aa7d"
+  integrity sha512-5jeUUNSAElwNnFkb6LE1b/YlOHlaFWKN8N8BBdHZWIK6QQzb34nuXkbKJZxn7xK5VrGpCAraHayycQf7KpIJOw==
   dependencies:
     make-error-cause "^2.2.0"
     pump "^3.0.0"
 
-popsicle-transport-xhr@^1.0.0:
+popsicle-transport-xhr@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/popsicle-transport-xhr/-/popsicle-transport-xhr-1.0.2.tgz#aa4b7ab74d37f880cf857622cbbaf5ead3e43cb2"
   integrity sha512-v9eAJnj1tydT4VmDdyKFE1z/+oL01vB7AS3LfSFMAYv33dzqlxtbApKALcYWBQotIqw3FoIqd2FiDR6qJsOxtA==
@@ -11482,18 +11482,18 @@ popsicle-user-agent@^1.0.0:
   resolved "https://registry.yarnpkg.com/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz#976af355b605966168733c4e03ad1e4f783f5d48"
   integrity sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==
 
-popsicle@12.0.4:
-  version "12.0.4"
-  resolved "https://registry.yarnpkg.com/popsicle/-/popsicle-12.0.4.tgz#297adb1132a79fdbc54ca902645811b177f6234f"
-  integrity sha512-UuxhAFa4RXBecC6ZK24sKra/9va1bTxnb3CQpFsm+VBW72sl+UtTAmZv7LZTvvDNnGusAqisN+a6xSN9xSQzZA==
+popsicle@^12.0.5:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/popsicle/-/popsicle-12.0.5.tgz#3c55edf2857522e20e2e0e2ecf88c7fe02126b19"
+  integrity sha512-PZt2+KfNQVwYXEwaAdJPLsYFJ+j0M25+26GhBovxhq9TZFRJfigAlJ5JfioCf/9R4RcTSu9VeaovJcb20Br7mw==
   dependencies:
     popsicle-content-encoding "^1.0.0"
     popsicle-cookie-jar "^1.0.0"
-    popsicle-redirects "^1.0.0"
-    popsicle-transport-http "^1.0.0"
-    popsicle-transport-xhr "^1.0.0"
+    popsicle-redirects "^1.1.0"
+    popsicle-transport-http "^1.0.6"
+    popsicle-transport-xhr "^1.0.2"
     popsicle-user-agent "^1.0.0"
-    servie "^4.0.6"
+    servie "^4.3.2"
     throwback "^4.1.0"
     tough-cookie "^3.0.1"
 
@@ -13013,7 +13013,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-servie@^4.0.6:
+servie@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/servie/-/servie-4.3.2.tgz#7168140d62cb9476cb8b184fc8ceda24d5154e7e"
   integrity sha512-1NpFf3LjkDDq4IIuBqtqHfSdPWhXpuyWwuBdwbifZjWSxQd8rCWz5W9AluxNvWfteM1qQ26puODIzWljvBJc5A==


### PR DESCRIPTION
**Changes included with this PR**
Fixes a bug with Oauth2 callback that needed us to use `window.location.href` instead of location hash because the `client-oauth2` lib was updated and no longer uses location hash

**Checklist**

- [x] tests are included and passing
- [x] code is [transpiled](https://github.com/onaio/js-tools#transpiling-the-package-and-generating-type-definations-for-it)
