### PR TITLE
Update table headers on columns prop change

### DIFF
--- a/packages/DrillDownTable/dist/components/DrillDownTable.js
+++ b/packages/DrillDownTable/dist/components/DrillDownTable.js
@@ -49,7 +49,7 @@ function DrillDownTable(props) {
 
   var mutatedColumns = _react["default"].useMemo(function () {
     return columns.map(mutateColumns);
-  }, []);
+  }, [columns]);
 
   var fetchData = _react["default"].useCallback(function (_ref) {
     var skipPageResetRef = _ref.skipPageResetRef,

--- a/packages/DrillDownTable/src/components/DrillDownTable.tsx
+++ b/packages/DrillDownTable/src/components/DrillDownTable.tsx
@@ -36,7 +36,7 @@ function DrillDownTable<D extends object>(props: DrillDownTableProps<D>) {
     data && parentIdentifierField ? data.map((el: Dictionary) => el[parentIdentifierField]) : [];
   const [pageData, setPageData] = useState<D[]>([]);
 
-  const mutatedColumns = React.useMemo(() => columns.map(mutateColumns), []) as Array<
+  const mutatedColumns = React.useMemo(() => columns.map(mutateColumns), [columns]) as Array<
     DrillDownColumn<D>
   >;
 

--- a/packages/DrillDownTable/src/components/tests/index.test.tsx
+++ b/packages/DrillDownTable/src/components/tests/index.test.tsx
@@ -344,4 +344,40 @@ describe('DrillDownTable', () => {
     renderTable(wrapper, 'page 2 ');
     wrapper.unmount();
   });
+
+  it('columns changes are picked instantly', () => {
+    const textNode =
+      'You start forgetting the things you should remember and remembering the things you should forget.';
+    const CustomNullData = () => <div id="#ghost">{textNode}</div>;
+    const columns = [
+      {
+        Header: 'Name',
+        accessor: 'location'
+      }
+    ];
+    const newColumns = [
+      {
+        Header: 'Parent ID',
+        accessor: 'parent_id'
+      }
+    ];
+    const props: any = {
+      columns,
+      data: [],
+      renderNullDataComponent: CustomNullData
+    };
+
+    const wrapper = mount(<DrillDownTable {...props} />);
+    expect(wrapper.text()).toMatchInlineSnapshot(
+      `"NameYou start forgetting the things you should remember and remembering the things you should forget."`
+    );
+
+    // change columns props
+    wrapper.setProps({ columns: newColumns });
+    wrapper.update();
+    expect(wrapper.text()).toMatchInlineSnapshot(
+      `"Parent IDYou start forgetting the things you should remember and remembering the things you should forget."`
+    );
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
Add `columns` prop as a dependency of the memoized table columns to allow re-computation on columns change. 
