### PR TITLE
Fix map rerender on hover

### DIFF
--- a/packages/GisidaLite/dist/constants.js
+++ b/packages/GisidaLite/dist/constants.js
@@ -1,0 +1,25 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.GEOJSON_DATA = exports.DEFAULT_CONTAINER_STYLES = exports.DEFAULT_STYLES = exports.DEFAULT_ATTRIBUTION = exports.DEFAULT_ACCESS_TOKEN = void 0;
+var DEFAULT_ACCESS_TOKEN = 'pk.eyJ1Ijoib25hIiwiYSI6IlVYbkdyclkifQ.0Bz-QOOXZZK01dq4MuMImQ';
+exports.DEFAULT_ACCESS_TOKEN = DEFAULT_ACCESS_TOKEN;
+var DEFAULT_ATTRIBUTION = '&copy; ONA Engineering';
+exports.DEFAULT_ATTRIBUTION = DEFAULT_ATTRIBUTION;
+var DEFAULT_STYLES = 'mapbox://styles/mapbox/streets-v9';
+exports.DEFAULT_STYLES = DEFAULT_STYLES;
+var DEFAULT_CONTAINER_STYLES = {
+  height: '100vh',
+  width: '100vw'
+};
+exports.DEFAULT_CONTAINER_STYLES = DEFAULT_CONTAINER_STYLES;
+var GEOJSON_DATA = {
+  geometry: {
+    coordinates: [0, 0],
+    type: 'Point'
+  },
+  type: 'Feature'
+};
+exports.GEOJSON_DATA = GEOJSON_DATA;

--- a/packages/GisidaLite/dist/index.js
+++ b/packages/GisidaLite/dist/index.js
@@ -1,0 +1,78 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.MemoizedGisidaLite = exports.GisidaLite = exports.arePropsEqual = exports.gisidaLiteDefaultProps = void 0;
+
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
+
+var _lodash = require("lodash");
+
+require("mapbox-gl/dist/mapbox-gl.css");
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactMapboxGl = _interopRequireWildcard(require("react-mapbox-gl"));
+
+var _constants = require("./constants");
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+var ReactMapboxGlProps = {
+  accessToken: _constants.DEFAULT_ACCESS_TOKEN,
+  attributionControl: true,
+  customAttribution: _constants.DEFAULT_ATTRIBUTION,
+  injectCSS: true
+};
+var mapProps = {
+  containerStyle: _constants.DEFAULT_CONTAINER_STYLES,
+  style: _constants.DEFAULT_STYLES
+};
+var gisidaLiteDefaultProps = {
+  layers: [_react["default"].createElement(_reactMapboxGl.GeoJSONLayer, {
+    key: "geoLayer",
+    data: _constants.GEOJSON_DATA,
+    symbolLayout: {
+      'icon-image': 'triangle-15'
+    }
+  })],
+  mapComponents: [_react["default"].createElement(_reactMapboxGl.ZoomControl, {
+    key: "zoomCtrl",
+    position: "top-right"
+  }), _react["default"].createElement(_reactMapboxGl.ScaleControl, {
+    key: "scalectrl",
+    position: "bottom-left"
+  })],
+  mapConfigs: mapProps,
+  reactMapboxGlMapFactoryUtilConfigs: ReactMapboxGlProps
+};
+exports.gisidaLiteDefaultProps = gisidaLiteDefaultProps;
+
+var GisidaLite = function GisidaLite(props) {
+  var mapConfigs = props.mapConfigs,
+      reactMapboxGlMapFactoryUtilConfigs = props.reactMapboxGlMapFactoryUtilConfigs,
+      mapComponents = props.mapComponents,
+      layers = props.layers;
+  var Mapbox = (0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs));
+  return _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents));
+};
+
+exports.GisidaLite = GisidaLite;
+GisidaLite.defaultProps = gisidaLiteDefaultProps;
+
+var arePropsEqual = function arePropsEqual(prevProps, nextProps) {
+  return (0, _lodash.isEqual)(prevProps.layers, nextProps.layers);
+};
+
+exports.arePropsEqual = arePropsEqual;
+
+var MemoizedGisidaLite = _react["default"].memo(GisidaLite, arePropsEqual);
+
+exports.MemoizedGisidaLite = MemoizedGisidaLite;

--- a/packages/GisidaLite/dist/index.js
+++ b/packages/GisidaLite/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+var _typeof = require("@babel/runtime/helpers/typeof");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -16,6 +16,10 @@ var _react = _interopRequireWildcard(require("react"));
 var _reactMapboxGl = _interopRequireWildcard(require("react-mapbox-gl"));
 
 var _constants = require("./constants");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var ReactMapboxGlProps = {
   accessToken: _constants.DEFAULT_ACCESS_TOKEN,
@@ -56,7 +60,7 @@ var GisidaLite = function GisidaLite(props) {
   var Mapbox = (0, _react.useMemo)(function () {
     return (0, _reactMapboxGl["default"])(reactMapboxGlConfigs);
   }, [reactMapboxGlConfigs]);
-  return _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents));
+  return Mapbox ? _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents)) : null;
 };
 
 exports.GisidaLite = GisidaLite;

--- a/packages/GisidaLite/dist/index.js
+++ b/packages/GisidaLite/dist/index.js
@@ -1,31 +1,29 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
 
-var _typeof = require("@babel/runtime/helpers/typeof");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.MemoizedGisidaLite = exports.GisidaLite = exports.arePropsEqual = exports.gisidaLiteDefaultProps = void 0;
+exports.MemoizedGisidaLite = exports.GisidaLite = exports.arePropsEqual = exports.gisidaLiteDefaultProps = exports.ReactMapboxGlProps = void 0;
 
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
+
+var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
 
 var _lodash = require("lodash");
 
 require("mapbox-gl/dist/mapbox-gl.css");
 
-var _react = _interopRequireDefault(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
 var _reactMapboxGl = _interopRequireWildcard(require("react-mapbox-gl"));
 
 var _constants = require("./constants");
 
-function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
-
-function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -35,12 +33,12 @@ var ReactMapboxGlProps = {
   customAttribution: _constants.DEFAULT_ATTRIBUTION,
   injectCSS: true
 };
+exports.ReactMapboxGlProps = ReactMapboxGlProps;
 var mapProps = {
   containerStyle: _constants.DEFAULT_CONTAINER_STYLES,
   style: _constants.DEFAULT_STYLES
 };
 var gisidaLiteDefaultProps = {
-  Mapbox: (0, _reactMapboxGl["default"])(_objectSpread({}, ReactMapboxGlProps)),
   layers: [_react["default"].createElement(_reactMapboxGl.GeoJSONLayer, {
     key: "geoLayer",
     data: _constants.GEOJSON_DATA,
@@ -65,13 +63,16 @@ var GisidaLite = function GisidaLite(props) {
       reactMapboxGlMapFactoryUtilConfigs = props.reactMapboxGlMapFactoryUtilConfigs,
       mapComponents = props.mapComponents,
       layers = props.layers;
-  var Mapbox = props.Mapbox;
 
-  _react["default"].useEffect(function () {
-    Mapbox = (0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs));
-  }, []);
+  var _useState = (0, _react.useState)(null),
+      _useState2 = (0, _slicedToArray2["default"])(_useState, 2),
+      Map = _useState2[0],
+      setMap = _useState2[1];
 
-  return _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents));
+  (0, _react.useEffect)(function () {
+    setMap((0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs)));
+  }, [reactMapboxGlMapFactoryUtilConfigs]);
+  return Map ? _react["default"].createElement(Map, mapConfigs, _react["default"].createElement(Map, null, layers, mapComponents)) : null;
 };
 
 exports.GisidaLite = GisidaLite;

--- a/packages/GisidaLite/dist/index.js
+++ b/packages/GisidaLite/dist/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+var _typeof = require("@babel/runtime/helpers/typeof");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -21,7 +21,11 @@ var _reactMapboxGl = _interopRequireWildcard(require("react-mapbox-gl"));
 
 var _constants = require("./constants");
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -67,7 +71,7 @@ var GisidaLite = function GisidaLite(props) {
     Mapbox = (0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs));
   }, []);
 
-  return Mapbox ? _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents)) : null;
+  return _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents));
 };
 
 exports.GisidaLite = GisidaLite;

--- a/packages/GisidaLite/dist/index.js
+++ b/packages/GisidaLite/dist/index.js
@@ -36,6 +36,7 @@ var mapProps = {
   style: _constants.DEFAULT_STYLES
 };
 var gisidaLiteDefaultProps = {
+  Mapbox: (0, _reactMapboxGl["default"])(_objectSpread({}, ReactMapboxGlProps)),
   layers: [_react["default"].createElement(_reactMapboxGl.GeoJSONLayer, {
     key: "geoLayer",
     data: _constants.GEOJSON_DATA,
@@ -60,8 +61,13 @@ var GisidaLite = function GisidaLite(props) {
       reactMapboxGlMapFactoryUtilConfigs = props.reactMapboxGlMapFactoryUtilConfigs,
       mapComponents = props.mapComponents,
       layers = props.layers;
-  var Mapbox = (0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs));
-  return _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents));
+  var Mapbox = props.Mapbox;
+
+  _react["default"].useEffect(function () {
+    Mapbox = (0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs));
+  }, []);
+
+  return Mapbox ? _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents)) : null;
 };
 
 exports.GisidaLite = GisidaLite;

--- a/packages/GisidaLite/dist/index.js
+++ b/packages/GisidaLite/dist/index.js
@@ -2,16 +2,10 @@
 
 var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.MemoizedGisidaLite = exports.GisidaLite = exports.arePropsEqual = exports.gisidaLiteDefaultProps = exports.ReactMapboxGlProps = void 0;
-
-var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
-var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
 
 var _lodash = require("lodash");
 
@@ -22,10 +16,6 @@ var _react = _interopRequireWildcard(require("react"));
 var _reactMapboxGl = _interopRequireWildcard(require("react-mapbox-gl"));
 
 var _constants = require("./constants");
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 var ReactMapboxGlProps = {
   accessToken: _constants.DEFAULT_ACCESS_TOKEN,
@@ -54,25 +44,19 @@ var gisidaLiteDefaultProps = {
     position: "bottom-left"
   })],
   mapConfigs: mapProps,
-  reactMapboxGlMapFactoryUtilConfigs: ReactMapboxGlProps
+  reactMapboxGlConfigs: ReactMapboxGlProps
 };
 exports.gisidaLiteDefaultProps = gisidaLiteDefaultProps;
 
 var GisidaLite = function GisidaLite(props) {
   var mapConfigs = props.mapConfigs,
-      reactMapboxGlMapFactoryUtilConfigs = props.reactMapboxGlMapFactoryUtilConfigs,
+      reactMapboxGlConfigs = props.reactMapboxGlConfigs,
       mapComponents = props.mapComponents,
       layers = props.layers;
-
-  var _useState = (0, _react.useState)(null),
-      _useState2 = (0, _slicedToArray2["default"])(_useState, 2),
-      Map = _useState2[0],
-      setMap = _useState2[1];
-
-  (0, _react.useEffect)(function () {
-    setMap((0, _reactMapboxGl["default"])(_objectSpread({}, reactMapboxGlMapFactoryUtilConfigs)));
-  }, [reactMapboxGlMapFactoryUtilConfigs]);
-  return Map ? _react["default"].createElement(Map, mapConfigs, _react["default"].createElement(Map, null, layers, mapComponents)) : null;
+  var Mapbox = (0, _react.useMemo)(function () {
+    return (0, _reactMapboxGl["default"])(reactMapboxGlConfigs);
+  }, [reactMapboxGlConfigs]);
+  return _react["default"].createElement(Mapbox, mapConfigs, _react["default"].createElement(_react["default"].Fragment, null, layers, mapComponents));
 };
 
 exports.GisidaLite = GisidaLite;

--- a/packages/GisidaLite/dist/types/index.d.ts
+++ b/packages/GisidaLite/dist/types/index.d.ts
@@ -18,7 +18,7 @@ export declare const gisidaLiteDefaultProps: GisidaLiteProps;
  * Inspired by GisidaLite component in reveal
  */
 declare const GisidaLite: {
-  (props: GisidaLiteProps): JSX.Element | null;
+  (props: GisidaLiteProps): JSX.Element;
   defaultProps: GisidaLiteProps;
 };
 /**
@@ -31,7 +31,7 @@ export declare const arePropsEqual: (
   nextProps: GisidaLiteProps
 ) => boolean;
 declare const MemoizedGisidaLite: React.MemoExoticComponent<{
-  (props: GisidaLiteProps): JSX.Element | null;
+  (props: GisidaLiteProps): JSX.Element;
   defaultProps: GisidaLiteProps;
 }>;
 export { GisidaLite, MemoizedGisidaLite };

--- a/packages/GisidaLite/dist/types/index.d.ts
+++ b/packages/GisidaLite/dist/types/index.d.ts
@@ -2,10 +2,16 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import React from 'react';
 import { FactoryParameters, Props } from 'react-mapbox-gl/lib/map';
 import { Events } from 'react-mapbox-gl/lib/map-events';
+/** ReactMapboxGlProps & mapProps props */
+export declare const ReactMapboxGlProps: {
+  accessToken: string;
+  attributionControl: boolean;
+  customAttribution: string;
+  injectCSS: boolean;
+};
 /** interface for  GisidaLite props */
 export interface GisidaLiteProps {
   layers: JSX.Element[];
-  Mapbox: typeof React.Component;
   mapConfigs: Props & Events;
   mapComponents: JSX.Element[];
   reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
@@ -18,7 +24,7 @@ export declare const gisidaLiteDefaultProps: GisidaLiteProps;
  * Inspired by GisidaLite component in reveal
  */
 declare const GisidaLite: {
-  (props: GisidaLiteProps): JSX.Element;
+  (props: GisidaLiteProps): JSX.Element | null;
   defaultProps: GisidaLiteProps;
 };
 /**
@@ -31,7 +37,7 @@ export declare const arePropsEqual: (
   nextProps: GisidaLiteProps
 ) => boolean;
 declare const MemoizedGisidaLite: React.MemoExoticComponent<{
-  (props: GisidaLiteProps): JSX.Element;
+  (props: GisidaLiteProps): JSX.Element | null;
   defaultProps: GisidaLiteProps;
 }>;
 export { GisidaLite, MemoizedGisidaLite };

--- a/packages/GisidaLite/dist/types/index.d.ts
+++ b/packages/GisidaLite/dist/types/index.d.ts
@@ -4,10 +4,11 @@ import { FactoryParameters, Props } from 'react-mapbox-gl/lib/map';
 import { Events } from 'react-mapbox-gl/lib/map-events';
 /** interface for  GisidaLite props */
 export interface GisidaLiteProps {
-  reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
+  layers: JSX.Element[];
+  Mapbox: typeof React.Component;
   mapConfigs: Props & Events;
   mapComponents: JSX.Element[];
-  layers: JSX.Element[];
+  reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
 }
 /** Default props for GisidaLite */
 export declare const gisidaLiteDefaultProps: GisidaLiteProps;
@@ -16,7 +17,10 @@ export declare const gisidaLiteDefaultProps: GisidaLiteProps;
  *
  * Inspired by GisidaLite component in reveal
  */
-declare const GisidaLite: React.FC<GisidaLiteProps>;
+declare const GisidaLite: {
+  (props: GisidaLiteProps): JSX.Element | null;
+  defaultProps: GisidaLiteProps;
+};
 /**
  * Custom equality method for React.memo
  * @param prevProps
@@ -26,5 +30,8 @@ export declare const arePropsEqual: (
   prevProps: GisidaLiteProps,
   nextProps: GisidaLiteProps
 ) => boolean;
-declare const MemoizedGisidaLite: React.NamedExoticComponent<GisidaLiteProps>;
+declare const MemoizedGisidaLite: React.MemoExoticComponent<{
+  (props: GisidaLiteProps): JSX.Element | null;
+  defaultProps: GisidaLiteProps;
+}>;
 export { GisidaLite, MemoizedGisidaLite };

--- a/packages/GisidaLite/dist/types/index.d.ts
+++ b/packages/GisidaLite/dist/types/index.d.ts
@@ -14,7 +14,7 @@ export interface GisidaLiteProps {
   layers: JSX.Element[];
   mapConfigs: Props & Events;
   mapComponents: JSX.Element[];
-  reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
+  reactMapboxGlConfigs: FactoryParameters;
 }
 /** Default props for GisidaLite */
 export declare const gisidaLiteDefaultProps: GisidaLiteProps;
@@ -24,7 +24,7 @@ export declare const gisidaLiteDefaultProps: GisidaLiteProps;
  * Inspired by GisidaLite component in reveal
  */
 declare const GisidaLite: {
-  (props: GisidaLiteProps): JSX.Element | null;
+  (props: GisidaLiteProps): JSX.Element;
   defaultProps: GisidaLiteProps;
 };
 /**
@@ -37,7 +37,7 @@ export declare const arePropsEqual: (
   nextProps: GisidaLiteProps
 ) => boolean;
 declare const MemoizedGisidaLite: React.MemoExoticComponent<{
-  (props: GisidaLiteProps): JSX.Element | null;
+  (props: GisidaLiteProps): JSX.Element;
   defaultProps: GisidaLiteProps;
 }>;
 export { GisidaLite, MemoizedGisidaLite };

--- a/packages/GisidaLite/dist/types/index.d.ts
+++ b/packages/GisidaLite/dist/types/index.d.ts
@@ -24,7 +24,7 @@ export declare const gisidaLiteDefaultProps: GisidaLiteProps;
  * Inspired by GisidaLite component in reveal
  */
 declare const GisidaLite: {
-  (props: GisidaLiteProps): JSX.Element;
+  (props: GisidaLiteProps): JSX.Element | null;
   defaultProps: GisidaLiteProps;
 };
 /**
@@ -37,7 +37,7 @@ export declare const arePropsEqual: (
   nextProps: GisidaLiteProps
 ) => boolean;
 declare const MemoizedGisidaLite: React.MemoExoticComponent<{
-  (props: GisidaLiteProps): JSX.Element;
+  (props: GisidaLiteProps): JSX.Element | null;
   defaultProps: GisidaLiteProps;
 }>;
 export { GisidaLite, MemoizedGisidaLite };

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -61,9 +61,9 @@ const GisidaLite = (props: GisidaLiteProps) => {
   /**
    * Re-instanciate Mapbox on configs change only
    */
-  const Mapbox = useMemo<typeof React.Component>(() => ReactMapboxGl(reactMapboxGlConfigs), [
-    reactMapboxGlConfigs
-  ]);
+  const Mapbox = useMemo<typeof React.Component>(() => {
+    return ReactMapboxGl(reactMapboxGlConfigs);
+  }, [reactMapboxGlConfigs]);
   return Mapbox ? (
     <Mapbox {...mapConfigs}>
       <>

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import ReactMapboxGl, { GeoJSONLayer, ScaleControl, ZoomControl } from 'react-mapbox-gl';
 import { FactoryParameters, Props } from 'react-mapbox-gl/lib/map';
 import { Events } from 'react-mapbox-gl/lib/map-events';
@@ -28,7 +28,7 @@ export interface GisidaLiteProps {
   layers: JSX.Element[];
   mapConfigs: Props & Events;
   mapComponents: JSX.Element[];
-  reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
+  reactMapboxGlConfigs: FactoryParameters;
 }
 
 /** Default props for GisidaLite */
@@ -47,7 +47,7 @@ export const gisidaLiteDefaultProps: GisidaLiteProps = {
     <ScaleControl key="scalectrl" position="bottom-left" />
   ],
   mapConfigs: mapProps,
-  reactMapboxGlMapFactoryUtilConfigs: ReactMapboxGlProps
+  reactMapboxGlConfigs: ReactMapboxGlProps
 };
 
 /**
@@ -57,20 +57,21 @@ export const gisidaLiteDefaultProps: GisidaLiteProps = {
  */
 
 const GisidaLite = (props: GisidaLiteProps) => {
-  const { mapConfigs, reactMapboxGlMapFactoryUtilConfigs, mapComponents, layers } = props;
-  const [Map, setMap] = useState<typeof React.Component | null>(null);
-  // instantiate MapFactory on reactMapboxGlMapFactoryUtilConfigs change
-  useEffect(() => {
-    setMap(ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs }));
-  }, [reactMapboxGlMapFactoryUtilConfigs]);
-  return Map ? (
-    <Map {...mapConfigs}>
-      <Map>
+  const { mapConfigs, reactMapboxGlConfigs, mapComponents, layers } = props;
+  /**
+   * Re-instanciate Mapbox on configs change only
+   */
+  const Mapbox = useMemo<typeof React.Component>(() => ReactMapboxGl(reactMapboxGlConfigs), [
+    reactMapboxGlConfigs
+  ]);
+  return (
+    <Mapbox {...mapConfigs}>
+      <>
         {layers}
         {mapComponents}
-      </Map>
-    </Map>
-  ) : null;
+      </>
+    </Mapbox>
+  );
 };
 
 GisidaLite.defaultProps = gisidaLiteDefaultProps;

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactMapboxGl, { GeoJSONLayer, ScaleControl, ZoomControl } from 'react-mapbox-gl';
 import { FactoryParameters, Props } from 'react-mapbox-gl/lib/map';
 import { Events } from 'react-mapbox-gl/lib/map-events';
@@ -26,7 +26,6 @@ const mapProps = {
 /** interface for  GisidaLite props */
 export interface GisidaLiteProps {
   layers: JSX.Element[];
-  Mapbox: typeof React.Component;
   mapConfigs: Props & Events;
   mapComponents: JSX.Element[];
   reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
@@ -34,7 +33,6 @@ export interface GisidaLiteProps {
 
 /** Default props for GisidaLite */
 export const gisidaLiteDefaultProps: GisidaLiteProps = {
-  Mapbox: ReactMapboxGl({ ...ReactMapboxGlProps }),
   layers: [
     <GeoJSONLayer
       key="geoLayer"
@@ -52,7 +50,6 @@ export const gisidaLiteDefaultProps: GisidaLiteProps = {
   reactMapboxGlMapFactoryUtilConfigs: ReactMapboxGlProps
 };
 
-// eslint-disable-next-line import/no-mutable-exports
 /**
  * Simple React mapbox gl renderer :)
  *
@@ -61,19 +58,21 @@ export const gisidaLiteDefaultProps: GisidaLiteProps = {
 
 const GisidaLite = (props: GisidaLiteProps) => {
   const { mapConfigs, reactMapboxGlMapFactoryUtilConfigs, mapComponents, layers } = props;
-  let { Mapbox } = props;
-  /** Instanciate map instance on mount only */
-  React.useEffect(() => {
-    Mapbox = ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs });
+  const [Map, setMap] = useState<typeof React.Component | null>(null);
+  useEffect(() => {
+    setMap(ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs }));
   }, []);
-  return (
-    <Mapbox {...mapConfigs}>
-      <>
+  useEffect(() => {
+    setMap(ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs }));
+  }, [reactMapboxGlMapFactoryUtilConfigs]);
+  return Map ? (
+    <Map {...mapConfigs}>
+      <Map>
         {layers}
         {mapComponents}
-      </>
-    </Mapbox>
-  );
+      </Map>
+    </Map>
+  ) : null;
 };
 
 GisidaLite.defaultProps = gisidaLiteDefaultProps;

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -64,14 +64,14 @@ const GisidaLite = (props: GisidaLiteProps) => {
   const Mapbox = useMemo<typeof React.Component>(() => ReactMapboxGl(reactMapboxGlConfigs), [
     reactMapboxGlConfigs
   ]);
-  return (
+  return Mapbox ? (
     <Mapbox {...mapConfigs}>
       <>
         {layers}
         {mapComponents}
       </>
     </Mapbox>
-  );
+  ) : null;
 };
 
 GisidaLite.defaultProps = gisidaLiteDefaultProps;

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -25,14 +25,16 @@ const mapProps = {
 
 /** interface for  GisidaLite props */
 export interface GisidaLiteProps {
-  reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
+  layers: JSX.Element[];
+  Mapbox: typeof React.Component;
   mapConfigs: Props & Events;
   mapComponents: JSX.Element[];
-  layers: JSX.Element[];
+  reactMapboxGlMapFactoryUtilConfigs: FactoryParameters;
 }
 
 /** Default props for GisidaLite */
 export const gisidaLiteDefaultProps: GisidaLiteProps = {
+  Mapbox: ReactMapboxGl({ ...ReactMapboxGlProps }),
   layers: [
     <GeoJSONLayer
       key="geoLayer"
@@ -49,22 +51,29 @@ export const gisidaLiteDefaultProps: GisidaLiteProps = {
   mapConfigs: mapProps,
   reactMapboxGlMapFactoryUtilConfigs: ReactMapboxGlProps
 };
+
+// eslint-disable-next-line import/no-mutable-exports
 /**
  * Simple React mapbox gl renderer :)
  *
  * Inspired by GisidaLite component in reveal
  */
-const GisidaLite: React.FC<GisidaLiteProps> = (props: GisidaLiteProps) => {
+
+const GisidaLite = (props: GisidaLiteProps) => {
   const { mapConfigs, reactMapboxGlMapFactoryUtilConfigs, mapComponents, layers } = props;
-  const Mapbox = ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs });
-  return (
+  let { Mapbox } = props;
+  /** Instanciate map instance on mount only */
+  React.useEffect(() => {
+    Mapbox = ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs });
+  }, []);
+  return Mapbox ? (
     <Mapbox {...mapConfigs}>
       <>
         {layers}
         {mapComponents}
       </>
     </Mapbox>
-  );
+  ) : null;
 };
 
 GisidaLite.defaultProps = gisidaLiteDefaultProps;

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -12,7 +12,7 @@ import {
   GEOJSON_DATA
 } from './constants';
 /** ReactMapboxGlProps & mapProps props */
-const ReactMapboxGlProps = {
+export const ReactMapboxGlProps = {
   accessToken: DEFAULT_ACCESS_TOKEN,
   attributionControl: true,
   customAttribution: DEFAULT_ATTRIBUTION,
@@ -59,9 +59,7 @@ export const gisidaLiteDefaultProps: GisidaLiteProps = {
 const GisidaLite = (props: GisidaLiteProps) => {
   const { mapConfigs, reactMapboxGlMapFactoryUtilConfigs, mapComponents, layers } = props;
   const [Map, setMap] = useState<typeof React.Component | null>(null);
-  useEffect(() => {
-    setMap(ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs }));
-  }, []);
+  // instantiate MapFactory on reactMapboxGlMapFactoryUtilConfigs change
   useEffect(() => {
     setMap(ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs }));
   }, [reactMapboxGlMapFactoryUtilConfigs]);

--- a/packages/GisidaLite/src/index.tsx
+++ b/packages/GisidaLite/src/index.tsx
@@ -66,14 +66,14 @@ const GisidaLite = (props: GisidaLiteProps) => {
   React.useEffect(() => {
     Mapbox = ReactMapboxGl({ ...reactMapboxGlMapFactoryUtilConfigs });
   }, []);
-  return Mapbox ? (
+  return (
     <Mapbox {...mapConfigs}>
       <>
         {layers}
         {mapComponents}
       </>
     </Mapbox>
-  ) : null;
+  );
 };
 
 GisidaLite.defaultProps = gisidaLiteDefaultProps;

--- a/packages/GisidaLite/src/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/GisidaLite/src/tests/__snapshots__/index.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`component/GisidaLite renders component correctly: gisida lite render 1`
       "style": "mapbox://styles/mapbox/streets-v9",
     }
   }
-  reactMapboxGlMapFactoryUtilConfigs={
+  reactMapboxGlConfigs={
     Object {
       "accessToken": "pk.eyJ1Ijoib25hIiwiYSI6IlVYbkdyclkifQ.0Bz-QOOXZZK01dq4MuMImQ",
       "attributionControl": true,
@@ -93,7 +93,7 @@ Object {
     },
     "style": "mapbox://styles/mapbox/streets-v9",
   },
-  "reactMapboxGlMapFactoryUtilConfigs": Object {
+  "reactMapboxGlConfigs": Object {
     "accessToken": "pk.eyJ1Ijoib25hIiwiYSI6IlVYbkdyclkifQ.0Bz-QOOXZZK01dq4MuMImQ",
     "attributionControl": true,
     "customAttribution": "&copy; ONA Engineering",

--- a/packages/GisidaLite/src/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/GisidaLite/src/tests/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`component/GisidaLite renders component correctly: gisida lite render 1`] = `
+<GisidaLite
+  layers={
+    Array [
+      <MappedComponent
+        data={
+          Object {
+            "geometry": Object {
+              "coordinates": Array [
+                0,
+                0,
+              ],
+              "type": "Point",
+            },
+            "type": "Feature",
+          }
+        }
+        symbolLayout={
+          Object {
+            "icon-image": "triangle-15",
+          }
+        }
+      />,
+    ]
+  }
+  mapComponents={
+    Array [
+      <MappedComponent
+        position="top-right"
+      />,
+      <MappedComponent
+        position="bottom-left"
+      />,
+    ]
+  }
+  mapConfigs={
+    Object {
+      "containerStyle": Object {
+        "height": "100vh",
+        "width": "100vw",
+      },
+      "style": "mapbox://styles/mapbox/streets-v9",
+    }
+  }
+  reactMapboxGlMapFactoryUtilConfigs={
+    Object {
+      "accessToken": "pk.eyJ1Ijoib25hIiwiYSI6IlVYbkdyclkifQ.0Bz-QOOXZZK01dq4MuMImQ",
+      "attributionControl": true,
+      "customAttribution": "&copy; ONA Engineering",
+      "injectCSS": true,
+    }
+  }
+/>
+`;
+
+exports[`component/GisidaLite renders props correctly: gisida lite props 1`] = `
+Object {
+  "layers": Array [
+    <MappedComponent
+      data={
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              0,
+              0,
+            ],
+            "type": "Point",
+          },
+          "type": "Feature",
+        }
+      }
+      symbolLayout={
+        Object {
+          "icon-image": "triangle-15",
+        }
+      }
+    />,
+  ],
+  "mapComponents": Array [
+    <MappedComponent
+      position="top-right"
+    />,
+    <MappedComponent
+      position="bottom-left"
+    />,
+  ],
+  "mapConfigs": Object {
+    "containerStyle": Object {
+      "height": "100vh",
+      "width": "100vw",
+    },
+    "style": "mapbox://styles/mapbox/streets-v9",
+  },
+  "reactMapboxGlMapFactoryUtilConfigs": Object {
+    "accessToken": "pk.eyJ1Ijoib25hIiwiYSI6IlVYbkdyclkifQ.0Bz-QOOXZZK01dq4MuMImQ",
+    "attributionControl": true,
+    "customAttribution": "&copy; ONA Engineering",
+    "injectCSS": true,
+  },
+}
+`;

--- a/packages/GisidaLite/src/tests/index.test.tsx
+++ b/packages/GisidaLite/src/tests/index.test.tsx
@@ -1,10 +1,55 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import React from 'react';
-import { arePropsEqual, gisidaLiteDefaultProps, GisidaLiteProps, MemoizedGisidaLite } from '../';
+import ReactMapboxGl from 'react-mapbox-gl';
+import {
+  arePropsEqual,
+  gisidaLiteDefaultProps,
+  GisidaLiteProps,
+  MemoizedGisidaLite,
+  ReactMapboxGlProps
+} from '..';
+
+jest.mock('react-mapbox-gl');
 
 describe('component/GisidaLite', () => {
   it('renders without crashing', () => {
     shallow(<MemoizedGisidaLite {...gisidaLiteDefaultProps} />);
+  });
+  it('renders props correctly', () => {
+    const wrapper = mount(<MemoizedGisidaLite {...gisidaLiteDefaultProps} />);
+    expect(wrapper.props()).toMatchSnapshot('gisida lite props');
+  });
+  it('renders component correctly', () => {
+    const wrapper = mount(<MemoizedGisidaLite {...gisidaLiteDefaultProps} />);
+    expect(toJson(wrapper)).toMatchSnapshot('gisida lite render');
+  });
+  it('reacts to props changes accordingly in relation to ReactMapboxGl constructor', () => {
+    const updatedReactMapboxglProps = {
+      accessToken: '',
+      attributionControl: true,
+      customAttribution: '',
+      injectCSS: true
+    };
+    const mockReactMapboxGlMock = jest.fn();
+    (ReactMapboxGl as jest.Mock).mockImplementationOnce(() => mockReactMapboxGlMock);
+
+    const wrapper = mount(<MemoizedGisidaLite {...gisidaLiteDefaultProps} />);
+    expect(mockReactMapboxGlMock).toHaveBeenCalledTimes(1);
+    expect(wrapper.props().reactMapboxGlMapFactoryUtilConfigs).toEqual(ReactMapboxGlProps);
+    // should not re-instanciate reactmapboxgl on other props change
+    wrapper.setProps({
+      ...gisidaLiteDefaultProps,
+      layers: []
+    });
+    expect(mockReactMapboxGlMock).toHaveBeenCalledTimes(1);
+    expect(wrapper.props().reactMapboxGlMapFactoryUtilConfigs).toEqual(ReactMapboxGlProps);
+    // should re-instanciate map on reactmapboxgl factory options change
+    wrapper.setProps({
+      ...gisidaLiteDefaultProps,
+      reactMapboxGlMapFactoryUtilConfigs: updatedReactMapboxglProps
+    });
+    expect(wrapper.props().reactMapboxGlMapFactoryUtilConfigs).toEqual(updatedReactMapboxglProps);
   });
   it('returns false if layers length has changed', () => {
     const prevProps = {

--- a/packages/GisidaLite/src/tests/index.test.tsx
+++ b/packages/GisidaLite/src/tests/index.test.tsx
@@ -36,20 +36,20 @@ describe('component/GisidaLite', () => {
 
     const wrapper = mount(<MemoizedGisidaLite {...gisidaLiteDefaultProps} />);
     expect(mockReactMapboxGlMock).toHaveBeenCalledTimes(1);
-    expect(wrapper.props().reactMapboxGlMapFactoryUtilConfigs).toEqual(ReactMapboxGlProps);
+    expect(wrapper.props().reactMapboxGlConfigs).toEqual(ReactMapboxGlProps);
     // should not re-instanciate reactmapboxgl on other props change
     wrapper.setProps({
       ...gisidaLiteDefaultProps,
       layers: []
     });
     expect(mockReactMapboxGlMock).toHaveBeenCalledTimes(1);
-    expect(wrapper.props().reactMapboxGlMapFactoryUtilConfigs).toEqual(ReactMapboxGlProps);
+    expect(wrapper.props().reactMapboxGlConfigs).toEqual(ReactMapboxGlProps);
     // should re-instanciate map on reactmapboxgl factory options change
     wrapper.setProps({
       ...gisidaLiteDefaultProps,
-      reactMapboxGlMapFactoryUtilConfigs: updatedReactMapboxglProps
+      reactMapboxGlConfigs: updatedReactMapboxglProps
     });
-    expect(wrapper.props().reactMapboxGlMapFactoryUtilConfigs).toEqual(updatedReactMapboxglProps);
+    expect(wrapper.props().reactMapboxGlConfigs).toEqual(updatedReactMapboxglProps);
   });
   it('returns false if layers length has changed', () => {
     const prevProps = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/onaio/js-tools#contribution-guidelines
-->

**closes #177**
<!-- What issue does this pr close -->

**Changes included with this PR**
**Problem**
Instantiating the Map inside the component causes map re-renders on the firing map events/change (more info on this can be found [here](https://github.com/alex3165/react-mapbox-gl/issues/888)). 

**Attempted solution**
This pr set's the map instance on default props then overrides the same inside a  useEffect hook that only gets called on the component mount, this ensures the Map instance is loaded once and changes in the component props or map events do not recreate the map instance causing re-renders.

**Testing the fix**
In terms of testing, I haven't found a nice way to handle check if ReactmapboxGl is called on the mount and not called when props change. I'm thinking of adding a ReactMapboxGl method to props then mock and assert the same. I'm quite not sure if this is fine since we will be adding it to props for testing purposes only
 
 - Ensures react-mapbox-gl instance is created on mount only.
<!--
list of non-trivial changes included with the PR
-->

**Checklist**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are included and passing (Default props updated on tests)
- [x] code is [transpiled](https://github.com/onaio/js-tools#transpiling-the-package-and-generating-type-definations-for-it)
