### PR TITLE
Publish Gisidalite package  &Bump up versions for other packages

### DIFF
--- a/packages/DrillDownTable/CHANGELOG.md
+++ b/packages/DrillDownTable/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6](https://github.com/onaio/js-tools/compare/@onaio/drill-down-table@1.0.5...@onaio/drill-down-table@1.0.6) (2021-05-12)
+
+**Note:** Version bump only for package @onaio/drill-down-table
+
 ## [1.0.5](https://github.com/onaio/js-tools/compare/@onaio/drill-down-table@1.0.3...@onaio/drill-down-table@1.0.5) (2021-01-07)
 
 **Note:** Version bump only for package @onaio/drill-down-table

--- a/packages/DrillDownTable/package.json
+++ b/packages/DrillDownTable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onaio/drill-down-table",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "DrillDownTable",
   "main": "dist/index.js",
   "types": "dist/types",

--- a/packages/GisidaLite/CHANGELOG.md
+++ b/packages/GisidaLite/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1 (2021-05-12)
+
+**Note:** Version bump only for package @onaio/gisida-lite

--- a/packages/GisidaLite/package.json
+++ b/packages/GisidaLite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onaio/gisida-lite",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Mininimal map wrapper for MAPBOX GL JS",
   "main": "dist/index.js",
   "types": "dist/types",

--- a/packages/Loaders/CHANGELOG.md
+++ b/packages/Loaders/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.3](https://github.com/onaio/js-tools/compare/@onaio/loaders@0.0.2...@onaio/loaders@0.0.3) (2021-05-12)
+
+**Note:** Version bump only for package @onaio/loaders
+
 ## [0.0.2](https://github.com/onaio/js-tools/compare/@onaio/loaders@0.0.1...@onaio/loaders@0.0.2) (2021-01-07)
 
 **Note:** Version bump only for package @onaio/loaders

--- a/packages/Loaders/package.json
+++ b/packages/Loaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onaio/loaders",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "types": " dist/types",
   "description": "Loading components for your everyday use",
   "main": "dist/index.js",

--- a/packages/connected-private-route/CHANGELOG.md
+++ b/packages/connected-private-route/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.13](https://github.com/onaio/js-tools/compare/@onaio/connected-private-route@0.0.12...@onaio/connected-private-route@0.0.13) (2021-05-12)
+
+**Note:** Version bump only for package @onaio/connected-private-route
+
 ## [0.0.12](https://github.com/onaio/js-tools/compare/@onaio/connected-private-route@0.0.11...@onaio/connected-private-route@0.0.12) (2021-01-07)
 
 **Note:** Version bump only for package @onaio/connected-private-route

--- a/packages/connected-private-route/package.json
+++ b/packages/connected-private-route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onaio/connected-private-route",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Declarative private routing for React and Redux",
   "main": "dist/index.js",
   "types": "dist/types",
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@onaio/session-reducer": "^0.0.12"
+    "@onaio/session-reducer": "^0.0.13"
   },
   "peerDependencies": {
     "@types/react-redux": "^7.0.8",

--- a/packages/gatekeeper/CHANGELOG.md
+++ b/packages/gatekeeper/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/onaio/js-tools/compare/@onaio/gatekeeper@0.1.1...@onaio/gatekeeper@0.1.2) (2021-05-12)
+
+**Note:** Version bump only for package @onaio/gatekeeper
+
 ## [0.1.1](https://github.com/onaio/js-tools/compare/@onaio/gatekeeper@0.1.0...@onaio/gatekeeper@0.1.1) (2021-01-07)
 
 **Note:** Version bump only for package @onaio/gatekeeper

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onaio/gatekeeper",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Reusable tools for adding authentication to your React app",
   "main": "dist/index.js",
   "types": "dist/types",
@@ -31,7 +31,7 @@
   "author": "Ona Engineering",
   "license": "Apache-2.0",
   "dependencies": {
-    "@onaio/session-reducer": "^0.0.12",
+    "@onaio/session-reducer": "^0.0.13",
     "client-oauth2": "^4.3.3",
     "query-string": "^6.4.2",
     "reactstrap": "^7.1.0"

--- a/packages/session-reducer/CHANGELOG.md
+++ b/packages/session-reducer/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.13](https://github.com/onaio/js-tools/compare/@onaio/session-reducer@0.0.12...@onaio/session-reducer@0.0.13) (2021-05-12)
+
+**Note:** Version bump only for package @onaio/session-reducer
+
 ## [0.0.12](https://github.com/onaio/js-tools/compare/@onaio/session-reducer@0.0.11...@onaio/session-reducer@0.0.12) (2021-01-07)
 
 **Note:** Version bump only for package @onaio/session-reducer

--- a/packages/session-reducer/package.json
+++ b/packages/session-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onaio/session-reducer",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A simple configurable session reducer",
   "main": "dist/index.js",
   "types": "dist/types",


### PR DESCRIPTION
 Changelog and version updates for:

 - @onaio/drill-down-table@1.0.6
 - @onaio/gisida-lite@0.0.1
 - @onaio/loaders@0.0.3
 - @onaio/connected-private-route@0.0.13
 - @onaio/gatekeeper@0.1.2
 - @onaio/session-reducer@0.0.13
