### PR TITLE
Guard against navigation to disabled routes

### DIFF
--- a/packages/connected-private-route/README.md
+++ b/packages/connected-private-route/README.md
@@ -21,6 +21,8 @@ If the path `/dashboard` routes to this component like so:
                 component={Dashboard}
                 redirectPath="/login"
                 disableLoginProtection=false
+                routerEnabled=true
+                routerDisabledRedirectPath='/'
               />
               <Route component={NotFound} />
             </Switch>
@@ -50,6 +52,8 @@ class App extends Component {
                 path="/"
                 component={Home}
                 redirectPath="/login"
+                routerEnabled=true
+                routerDisabledRedirectPath='/'
                 disableLoginProtection=false
               />
               <Route component={NotFound} />
@@ -72,3 +76,5 @@ Behind the scenes, it works with the [session reducer](https://github.com/onaio/
 
 - **disableLoginProtection**: if this is true, we don't check if the user is authenticated. Useful for turning off login protection without doing much else. Default value is false.
 - **redirectPath**: the path that the user will be redirected to if they are not logged in. Default is "/login".
+- **routerEnabled**: optional prop -check if user is allowed to navigate to this route
+- **routerDisabledRedirectPath**: optional prop - redirect to path given if the router is disabled

--- a/packages/connected-private-route/README.md
+++ b/packages/connected-private-route/README.md
@@ -76,5 +76,5 @@ Behind the scenes, it works with the [session reducer](https://github.com/onaio/
 
 - **disableLoginProtection**: if this is true, we don't check if the user is authenticated. Useful for turning off login protection without doing much else. Default value is false.
 - **redirectPath**: the path that the user will be redirected to if they are not logged in. Default is "/login".
-- **routerEnabled**: optional prop -check if user is allowed to navigate to this route
-- **routerDisabledRedirectPath**: optional prop - redirect to path given if the router is disabled
+- **routerEnabled**: check if user is allowed to navigate to this route. Is a protection against navigation to disabled routes. Default is true.
+- **routerDisabledRedirectPath**: redirect path if the router is disabled. Default is "/".

--- a/packages/connected-private-route/dist/index.js
+++ b/packages/connected-private-route/dist/index.js
@@ -25,7 +25,8 @@ var defaultPrivateRouteProps = {
   authenticated: false,
   disableLoginProtection: false,
   redirectPath: '/login',
-  routerDisabledRedirectPath: '/'
+  routerDisabledRedirectPath: '/',
+  routerEnabled: true
 };
 
 var PrivateRoute = function PrivateRoute(props) {
@@ -43,15 +44,15 @@ var PrivateRoute = function PrivateRoute(props) {
   }));
   return _react["default"].createElement(_reactRouterDom.Route, (0, _extends2["default"])({}, theOtherProps, {
     render: function render(routeProps) {
-      if (routerEnabled === false) {
+      if (routerEnabled) {
+        return (authenticated === true || disableLoginProtection === true) && Component ? _react["default"].createElement(Component, (0, _extends2["default"])({}, routeProps, theOtherProps)) : _react["default"].createElement(_reactRouterDom.Redirect, {
+          to: fullRedirectPath
+        });
+      } else {
         return _react["default"].createElement(_reactRouterDom.Redirect, {
           to: routerDisabledRedirectPath
         });
       }
-
-      return (authenticated === true || disableLoginProtection === true) && Component ? _react["default"].createElement(Component, (0, _extends2["default"])({}, routeProps, theOtherProps)) : _react["default"].createElement(_reactRouterDom.Redirect, {
-        to: fullRedirectPath
-      });
     }
   }));
 };

--- a/packages/connected-private-route/dist/index.js
+++ b/packages/connected-private-route/dist/index.js
@@ -24,7 +24,8 @@ var _reactRouterDom = require("react-router-dom");
 var defaultPrivateRouteProps = {
   authenticated: false,
   disableLoginProtection: false,
-  redirectPath: '/login'
+  redirectPath: '/login',
+  routerDisabledRedirectPath: '/'
 };
 
 var PrivateRoute = function PrivateRoute(props) {
@@ -32,14 +33,22 @@ var PrivateRoute = function PrivateRoute(props) {
       authenticated = props.authenticated,
       disableLoginProtection = props.disableLoginProtection,
       redirectPath = props.redirectPath,
+      routerEnabled = props.routerEnabled,
+      routerDisabledRedirectPath = props.routerDisabledRedirectPath,
       location = props.location,
-      theOtherProps = (0, _objectWithoutProperties2["default"])(props, ["component", "authenticated", "disableLoginProtection", "redirectPath", "location"]);
+      theOtherProps = (0, _objectWithoutProperties2["default"])(props, ["component", "authenticated", "disableLoginProtection", "redirectPath", "routerEnabled", "routerDisabledRedirectPath", "location"]);
   var currentPath = "".concat(location && location.pathname || '').concat(location && location.search || '').concat(location && location.hash || '');
   var fullRedirectPath = "".concat(redirectPath, "?").concat(_querystring["default"].stringify({
     next: currentPath
   }));
   return _react["default"].createElement(_reactRouterDom.Route, (0, _extends2["default"])({}, theOtherProps, {
     render: function render(routeProps) {
+      if (routerEnabled === false) {
+        return _react["default"].createElement(_reactRouterDom.Redirect, {
+          to: routerDisabledRedirectPath
+        });
+      }
+
       return (authenticated === true || disableLoginProtection === true) && Component ? _react["default"].createElement(Component, (0, _extends2["default"])({}, routeProps, theOtherProps)) : _react["default"].createElement(_reactRouterDom.Redirect, {
         to: fullRedirectPath
       });

--- a/packages/connected-private-route/dist/types/index.d.ts
+++ b/packages/connected-private-route/dist/types/index.d.ts
@@ -5,6 +5,8 @@ interface PrivateRouteProps extends RouteProps {
   authenticated: boolean /** is the current user authenticated */;
   disableLoginProtection: boolean /** should we disable login protection */;
   redirectPath: string /** redirect to this path is use if not authenticated */;
+  routerEnabled?: boolean /** is this route enabled */;
+  routerDisabledRedirectPath?: string /** redirect to this path if router is not enabled */;
 }
 /** The PrivateRoute component
  * This component is a simple wrapper around Route and takes all its props in
@@ -30,7 +32,7 @@ export { PrivateRoute };
  * If authenticated === true then render the component supplied
  * Otherwise redirect to the redirectPath
  */
-declare const ConnectedPrivateRoute: import('react-redux').ConnectedComponentClass<
+declare const ConnectedPrivateRoute: import('react-redux').ConnectedComponent<
   {
     (props: PrivateRouteProps): JSX.Element;
     defaultProps: Partial<PrivateRouteProps>;

--- a/packages/connected-private-route/dist/types/index.d.ts
+++ b/packages/connected-private-route/dist/types/index.d.ts
@@ -5,8 +5,8 @@ interface PrivateRouteProps extends RouteProps {
   authenticated: boolean /** is the current user authenticated */;
   disableLoginProtection: boolean /** should we disable login protection */;
   redirectPath: string /** redirect to this path is use if not authenticated */;
-  routerEnabled?: boolean /** is this route enabled */;
-  routerDisabledRedirectPath?: string /** redirect to this path if router is not enabled */;
+  routerDisabledRedirectPath: string /** redirect to this path if router is not enabled */;
+  routerEnabled: boolean /** is this route enabled */;
 }
 /** The PrivateRoute component
  * This component is a simple wrapper around Route and takes all its props in

--- a/packages/connected-private-route/src/index.tsx
+++ b/packages/connected-private-route/src/index.tsx
@@ -10,13 +10,16 @@ interface PrivateRouteProps extends RouteProps {
   authenticated: boolean /** is the current user authenticated */;
   disableLoginProtection: boolean /** should we disable login protection */;
   redirectPath: string /** redirect to this path is use if not authenticated */;
+  routerEnabled?: boolean /** is this route enabled */;
+  routerDisabledRedirectPath?: string /** redirect to this path if router is not enabled */;
 }
 
 /** declare default props for PrivateRoute */
 const defaultPrivateRouteProps: Partial<PrivateRouteProps> = {
   authenticated: false,
   disableLoginProtection: false,
-  redirectPath: '/login'
+  redirectPath: '/login',
+  routerDisabledRedirectPath: '/'
 };
 
 /** The PrivateRoute component
@@ -34,6 +37,8 @@ const PrivateRoute = (props: PrivateRouteProps) => {
     authenticated,
     disableLoginProtection,
     redirectPath,
+    routerEnabled,
+    routerDisabledRedirectPath,
     location,
     ...theOtherProps
   } = props;
@@ -48,13 +53,16 @@ const PrivateRoute = (props: PrivateRouteProps) => {
     /* tslint:disable jsx-no-lambda */
     <Route
       {...theOtherProps}
-      render={routeProps =>
-        (authenticated === true || disableLoginProtection === true) && Component ? (
+      render={routeProps => {
+        if (routerEnabled === false) {
+          return <Redirect to={routerDisabledRedirectPath as string} />;
+        }
+        return (authenticated === true || disableLoginProtection === true) && Component ? (
           <Component {...routeProps} {...theOtherProps} />
         ) : (
           <Redirect to={fullRedirectPath} />
-        )
-      }
+        );
+      }}
     />
     /* tslint:enable jsx-no-lambda */
   );

--- a/packages/connected-private-route/src/index.tsx
+++ b/packages/connected-private-route/src/index.tsx
@@ -10,8 +10,8 @@ interface PrivateRouteProps extends RouteProps {
   authenticated: boolean /** is the current user authenticated */;
   disableLoginProtection: boolean /** should we disable login protection */;
   redirectPath: string /** redirect to this path is use if not authenticated */;
-  routerEnabled?: boolean /** is this route enabled */;
-  routerDisabledRedirectPath?: string /** redirect to this path if router is not enabled */;
+  routerDisabledRedirectPath: string /** redirect to this path if router is not enabled */;
+  routerEnabled: boolean /** is this route enabled */;
 }
 
 /** declare default props for PrivateRoute */
@@ -19,7 +19,8 @@ const defaultPrivateRouteProps: Partial<PrivateRouteProps> = {
   authenticated: false,
   disableLoginProtection: false,
   redirectPath: '/login',
-  routerDisabledRedirectPath: '/'
+  routerDisabledRedirectPath: '/',
+  routerEnabled: true
 };
 
 /** The PrivateRoute component
@@ -54,14 +55,15 @@ const PrivateRoute = (props: PrivateRouteProps) => {
     <Route
       {...theOtherProps}
       render={routeProps => {
-        if (routerEnabled === false) {
-          return <Redirect to={routerDisabledRedirectPath as string} />;
+        if (routerEnabled) {
+          return (authenticated === true || disableLoginProtection === true) && Component ? (
+            <Component {...routeProps} {...theOtherProps} />
+          ) : (
+            <Redirect to={fullRedirectPath} />
+          );
+        } else {
+          return <Redirect to={routerDisabledRedirectPath} />;
         }
-        return (authenticated === true || disableLoginProtection === true) && Component ? (
-          <Component {...routeProps} {...theOtherProps} />
-        ) : (
-          <Redirect to={fullRedirectPath} />
-        );
       }}
     />
     /* tslint:enable jsx-no-lambda */

--- a/packages/connected-private-route/src/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/connected-private-route/src/tests/__snapshots__/index.test.tsx.snap
@@ -39,6 +39,33 @@ Object {
   "message": "what is dead may never die",
   "path": "/dashboard",
   "redirectPath": "/denied",
+  "routerDisabledRedirectPath": "/",
+  "routerEnabled": true,
+}
+`;
+
+exports[`ConnectedPrivateRoute renders as expected when router is disabled 1`] = `
+Object {
+  "action": "REPLACE",
+  "block": [Function],
+  "canGo": [Function],
+  "createHref": [Function],
+  "entries": Any<Array>,
+  "go": [Function],
+  "goBack": [Function],
+  "goForward": [Function],
+  "index": 0,
+  "length": 1,
+  "listen": [Function],
+  "location": ObjectContaining {
+    "hash": "",
+    "key": Any<String>,
+    "pathname": "/route_disabled",
+    "search": "",
+    "state": undefined,
+  },
+  "push": [Function],
+  "replace": [Function],
 }
 `;
 
@@ -91,6 +118,8 @@ exports[`ConnectedPrivateRoute renders without crashing when not authenticated 1
   }
   path="/"
   redirectPath="/denied"
+  routerDisabledRedirectPath="/"
+  routerEnabled={true}
 >
   <Route
     path="/"
@@ -140,6 +169,8 @@ exports[`ConnectedPrivateRoute works when connected to the redux store 1`] = `
   disableLoginProtection={false}
   dispatch={[Function]}
   redirectPath="/login"
+  routerDisabledRedirectPath="/"
+  routerEnabled={true}
 >
   <Route
     dispatch={[Function]}
@@ -164,6 +195,8 @@ Object {
   "disableLoginProtection": false,
   "dispatch": Any<Function>,
   "redirectPath": "/login",
+  "routerDisabledRedirectPath": "/",
+  "routerEnabled": true,
 }
 `;
 

--- a/packages/connected-private-route/src/tests/index.test.tsx
+++ b/packages/connected-private-route/src/tests/index.test.tsx
@@ -14,6 +14,11 @@ const TestComponent = (props: { [key: string]: any }) => {
   return <span>{props.someProp}</span>;
 };
 
+const disableRouteDefaultProps = {
+  routerDisabledRedirectPath: '/',
+  routerEnabled: true
+};
+
 describe('ConnectedPrivateRoute', () => {
   let flushThunks;
   let store: Store;
@@ -121,7 +126,10 @@ describe('ConnectedPrivateRoute', () => {
     expect(wrapper.find('TestComponent').length).toEqual(0);
     expect(wrapper.find('PrivateRoute').length).toEqual(1);
     expect(toJson(wrapper.find('PrivateRoute'))).toMatchSnapshot();
-    expect(wrapper.find('PrivateRoute').props()).toEqual(props);
+    expect(wrapper.find('PrivateRoute').props()).toEqual({
+      ...props,
+      ...disableRouteDefaultProps
+    });
     /** check that a redirect happened */
     expect(wrapper.find('Router').prop('history')).toMatchSnapshot({
       entries: expect.any(Array),
@@ -157,7 +165,10 @@ describe('ConnectedPrivateRoute', () => {
       </MemoryRouter>
     );
 
-    expect(wrapper.find('PrivateRoute').props()).toEqual(props);
+    expect(wrapper.find('PrivateRoute').props()).toEqual({
+      ...props,
+      ...disableRouteDefaultProps
+    });
     /** check that a redirect happened */
     expect(wrapper.find('Router').prop('history')).toMatchSnapshot({
       entries: expect.any(Array),
@@ -250,6 +261,50 @@ describe('ConnectedPrivateRoute', () => {
      * keys in the spanshot test
      */
     expect(toJson(wrapper.find('TestComponent span'))).toMatchSnapshot();
+    wrapper.unmount();
+  });
+
+  it('renders as expected when router is disabled', () => {
+    const routerDisabledRedirectPath = '/route_disabled';
+    const props = {
+      authenticated: true,
+      component: TestComponent,
+      disableLoginProtection: true,
+      location: {
+        hash: '#howdy',
+        pathname: '/dashboard',
+        search: '?q=string',
+        state: {}
+      },
+      path: '/',
+      redirectPath: '/denied',
+      routerDisabledRedirectPath,
+      routerEnabled: false
+    };
+    const wrapper = mount(
+      <MemoryRouter initialEntries={['/dashboard?q=string#howdy']} initialIndex={0}>
+        <PrivateRoute {...props} />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find('TestComponent').length).toEqual(0);
+    expect(wrapper.find('PrivateRoute').length).toEqual(1);
+    expect(wrapper.find('PrivateRoute').props()).toEqual({
+      ...props,
+      routerDisabledRedirectPath,
+      routerEnabled: false
+    });
+    /** check that a redirect happened */
+    expect(wrapper.find('Router').prop('history')).toMatchSnapshot({
+      entries: expect.any(Array),
+      location: expect.objectContaining({
+        hash: '',
+        key: expect.any(String),
+        pathname: routerDisabledRedirectPath,
+        search: '',
+        state: undefined
+      })
+    });
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
Part of https://github.com/onaio/reveal-frontend/issues/1551

**Changes included with this PR**
This PR changes `@onaio/connected-private-route` package.
Adds protection against navigation to disabled routes. If the router is disabled user is redirected to a provided path.

**Checklist**
- [x] tests are included and passing
- [x] documentation is changed or added
- [x] code is [transpiled](https://github.com/onaio/js-tools#transpiling-the-package-and-generating-type-definations-for-it)
